### PR TITLE
feat: cluster import export funcs

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -283,6 +283,91 @@ const docTemplate = `{
                 }
             }
         },
+        "/cluster/:cluster_name/export": {
+            "post": {
+                "description": "Export a Kubefirst cluster database entry",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cluster"
+                ],
+                "summary": "Export a Kubefirst cluster database entry",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cluster name",
+                        "name": "cluster_name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/types.JSONSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.JSONFailureResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/cluster/:cluster_name/import": {
+            "post": {
+                "description": "Import a Kubefirst cluster database entry",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cluster"
+                ],
+                "summary": "Import a Kubefirst cluster database entry",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cluster name",
+                        "name": "cluster_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Cluster import request in JSON format",
+                        "name": "request_body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.ImportClusterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/types.JSONSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.JSONFailureResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "description": "Return health status if the application is running.",
@@ -496,6 +581,13 @@ const docTemplate = `{
                 "stateStoreDetails": {
                     "$ref": "#/definitions/types.StateStoreDetails"
                 },
+                "status": {
+                    "type": "string"
+                },
+                "useTelemetry": {
+                    "description": "Telemetry",
+                    "type": "boolean"
+                },
                 "usersTerraformApplyCheck": {
                     "type": "boolean"
                 },
@@ -561,6 +653,17 @@ const docTemplate = `{
                         "mgmt",
                         "workload"
                     ]
+                }
+            }
+        },
+        "types.ImportClusterRequest": {
+            "type": "object",
+            "properties": {
+                "stateStoreCredentials": {
+                    "$ref": "#/definitions/types.StateStoreCredentials"
+                },
+                "stateStoreDetails": {
+                    "$ref": "#/definitions/types.StateStoreDetails"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -277,6 +277,91 @@
                 }
             }
         },
+        "/cluster/:cluster_name/export": {
+            "post": {
+                "description": "Export a Kubefirst cluster database entry",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cluster"
+                ],
+                "summary": "Export a Kubefirst cluster database entry",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cluster name",
+                        "name": "cluster_name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/types.JSONSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.JSONFailureResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/cluster/:cluster_name/import": {
+            "post": {
+                "description": "Import a Kubefirst cluster database entry",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "cluster"
+                ],
+                "summary": "Import a Kubefirst cluster database entry",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cluster name",
+                        "name": "cluster_name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Cluster import request in JSON format",
+                        "name": "request_body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.ImportClusterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/types.JSONSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/types.JSONFailureResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "description": "Return health status if the application is running.",
@@ -490,6 +575,13 @@
                 "stateStoreDetails": {
                     "$ref": "#/definitions/types.StateStoreDetails"
                 },
+                "status": {
+                    "type": "string"
+                },
+                "useTelemetry": {
+                    "description": "Telemetry",
+                    "type": "boolean"
+                },
                 "usersTerraformApplyCheck": {
                     "type": "boolean"
                 },
@@ -555,6 +647,17 @@
                         "mgmt",
                         "workload"
                     ]
+                }
+            }
+        },
+        "types.ImportClusterRequest": {
+            "type": "object",
+            "properties": {
+                "stateStoreCredentials": {
+                    "$ref": "#/definitions/types.StateStoreCredentials"
+                },
+                "stateStoreDetails": {
+                    "$ref": "#/definitions/types.StateStoreDetails"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -120,6 +120,11 @@ definitions:
         type: boolean
       stateStoreDetails:
         $ref: '#/definitions/types.StateStoreDetails'
+      status:
+        type: string
+      useTelemetry:
+        description: Telemetry
+        type: boolean
       usersTerraformApplyCheck:
         type: boolean
       vaultInitializedCheck:
@@ -168,6 +173,13 @@ definitions:
     - git_provider
     - git_token
     - type
+    type: object
+  types.ImportClusterRequest:
+    properties:
+      stateStoreCredentials:
+        $ref: '#/definitions/types.StateStoreCredentials'
+      stateStoreDetails:
+        $ref: '#/definitions/types.StateStoreDetails'
     type: object
   types.JSONFailureResponse:
     properties:
@@ -397,6 +409,62 @@ paths:
           schema:
             $ref: '#/definitions/types.JSONFailureResponse'
       summary: Create a Kubefirst cluster
+      tags:
+      - cluster
+  /cluster/:cluster_name/export:
+    post:
+      consumes:
+      - application/json
+      description: Export a Kubefirst cluster database entry
+      parameters:
+      - description: Cluster name
+        in: path
+        name: cluster_name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/types.JSONSuccessResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/types.JSONFailureResponse'
+      summary: Export a Kubefirst cluster database entry
+      tags:
+      - cluster
+  /cluster/:cluster_name/import:
+    post:
+      consumes:
+      - application/json
+      description: Import a Kubefirst cluster database entry
+      parameters:
+      - description: Cluster name
+        in: path
+        name: cluster_name
+        required: true
+        type: string
+      - description: Cluster import request in JSON format
+        in: body
+        name: request_body
+        required: true
+        schema:
+          $ref: '#/definitions/types.ImportClusterRequest'
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/types.JSONSuccessResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/types.JSONFailureResponse'
+      summary: Import a Kubefirst cluster database entry
       tags:
       - cluster
   /health:

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/swaggo/files v1.0.0
 	github.com/swaggo/gin-swagger v1.5.3
 	github.com/swaggo/swag v1.8.10
-	go.mongodb.org/mongo-driver v1.10.0
+	go.mongodb.org/mongo-driver v1.10.3
 	gopkg.in/ini.v1 v1.67.0
 	k8s.io/api v0.26.0
 	k8s.io/apimachinery v0.26.0
@@ -118,7 +118,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/golang/snappy v0.0.1 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
@@ -163,14 +163,14 @@ require (
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
-	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
+	github.com/montanaflynn/stats v0.6.6 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
@@ -215,10 +215,10 @@ require (
 	github.com/xdg-go/stringprep v1.0.3 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
-	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
+	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
-	golang.org/x/exp v0.0.0-20221012211006-4de253d81b95 // indirect
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -496,8 +496,9 @@ github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+Licev
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -767,8 +768,9 @@ github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
-github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
+github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -794,8 +796,9 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
-github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe h1:iruDEfMl2E6fbMZ9s0scYfZQ84/6SPL6zC8ACM2oIL0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v64GQ=
+github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b h1:1XF24mVaiu7u+CFywTdcDo2ie1pzzhwjt6RHqzpMU34=
@@ -1108,8 +1111,9 @@ github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c h1:3lbZUMbMiGUW/LMkfsEABsc5zNT9+b1CvsJx47JzJ8g=
 github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
-github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d h1:splanxYIlg+5LfHAM6xpdFEAYOk8iySO56hMFq6uLyA=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
+github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a h1:fZHgsYlfvtyqToslyjUt3VOPF4J7aK/3MPcK7xp3PDk=
+github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a/go.mod h1:ul22v+Nro/R083muKhosV54bj5niojjWZvU8xrevuH4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -1133,8 +1137,8 @@ go.etcd.io/etcd/client/v3 v3.5.1/go.mod h1:OnjH4M8OnAotwaB2l9bVgZzRFKru7/ZMoS46O
 go.etcd.io/etcd/pkg/v3 v3.5.0/go.mod h1:UzJGatBQ1lXChBkQF0AuAtkRQMYnHubxAEYIrC3MSsE=
 go.etcd.io/etcd/raft/v3 v3.5.0/go.mod h1:UFOHSIvO/nKwd4lhkwabrTD3cqW5yVyYYf/KlD00Szc=
 go.etcd.io/etcd/server/v3 v3.5.0/go.mod h1:3Ah5ruV+M+7RZr0+Y/5mNLwC+eQlni+mQmOVdCRJoS4=
-go.mongodb.org/mongo-driver v1.10.0 h1:UtV6N5k14upNp4LTduX0QCufG124fSu25Wz9tu94GLg=
-go.mongodb.org/mongo-driver v1.10.0/go.mod h1:wsihk0Kdgv8Kqu1Anit4sfK+22vSFbUrAVEYRhCXrA8=
+go.mongodb.org/mongo-driver v1.10.3 h1:XDQEvmh6z1EUsXuIkXE9TaVeqHw6SwS1uf93jFs0HBA=
+go.mongodb.org/mongo-driver v1.10.3/go.mod h1:z4XpeoU6w+9Vht+jAFyLgVrD+jGSQQe0+CBWFHNiHt8=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -1184,6 +1188,7 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
@@ -1217,8 +1222,8 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20210220032938-85be41e4509f/go.mod h1:I6l2HNBLBZEcrOoCpyKLdY2lHoRZ8lI4x60KMCQDft4=
 golang.org/x/exp v0.0.0-20210901193431-a062eea981d2/go.mod h1:a3o/VtDNHN+dCVLEpzjjUHOzR+Ln3DHX056ZPzoZGGA=
-golang.org/x/exp v0.0.0-20221012211006-4de253d81b95 h1:sBdrWpxhGDdTAYNqbgBLAR+ULAPPhfgncLr1X0lyWtg=
-golang.org/x/exp v0.0.0-20221012211006-4de253d81b95/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/internal/controller/state.go
+++ b/internal/controller/state.go
@@ -218,8 +218,9 @@ func (clctrl *ClusterController) StateStoreCreate() error {
 			}
 
 			stateStoreData := types.StateStoreDetails{
-				Name: bucket.Name,
-				ID:   bucket.ID,
+				Name:     bucket.Name,
+				ID:       bucket.ID,
+				Hostname: bucket.BucketURL,
 			}
 			err = clctrl.MdbCl.UpdateCluster(clctrl.ClusterName, "state_store_details", stateStoreData)
 			if err != nil {

--- a/internal/db/mongo.go
+++ b/internal/db/mongo.go
@@ -210,7 +210,7 @@ func (mdbcl *MongoDBClient) Export(clusterName string) error {
 
 // Restore retrieves a target cluster's database export from a state storage bucket and
 // attempts to insert the parsed cluster object into the database
-func (mdbcl *MongoDBClient) Restore(clusterName string) error {
+func (mdbcl *MongoDBClient) Restore(clusterName string, req *types.ImportClusterRequest) error {
 	var cluster *types.Cluster
 	var localFilePath = fmt.Sprintf("%s/%s.json", clusterImportsPath, clusterName)
 	var remoteFilePath = fmt.Sprintf("%s.json", clusterName)
@@ -228,17 +228,15 @@ func (mdbcl *MongoDBClient) Restore(clusterName string) error {
 	// todo: this needs to come from the provisioned mgmt cluster somehow
 	err := objectStorage.GetClusterObject(
 		&types.StateStoreCredentials{
-			AccessKeyID:     "",
-			SecretAccessKey: "",
-			Name:            clusterName,
-			ID:              "",
+			AccessKeyID:     req.StateStoreCredentials.AccessKeyID,
+			SecretAccessKey: req.StateStoreCredentials.SecretAccessKey,
 		},
+		// todo: to support AWS, additional fields are required
+		// AWSStateStoreBucket
+		// AWSArtifactsBucket
 		&types.StateStoreDetails{
-			Name:                clusterName,
-			ID:                  "",
-			Hostname:            "",
-			AWSStateStoreBucket: "",
-			AWSArtifactsBucket:  "",
+			Name:     req.StateStoreDetails.Name,
+			Hostname: req.StateStoreDetails.Hostname,
 		},
 		clusterName,
 		localFilePath,

--- a/internal/db/mongo.go
+++ b/internal/db/mongo.go
@@ -8,9 +8,11 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
+	"github.com/kubefirst/kubefirst-api/internal/objectStorage"
 	"github.com/kubefirst/kubefirst-api/internal/types"
 	log "github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
@@ -55,7 +57,7 @@ func (mdbcl *MongoDBClient) DeleteCluster(clusterName string) error {
 	// Delete
 	resp, err := mdbcl.Collection.DeleteOne(mdbcl.Context, filter)
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting cluster %s: %s", clusterName, err)
 	}
 
 	log.Infof("cluster deleted: %v", resp.DeletedCount)
@@ -70,7 +72,7 @@ func (mdbcl *MongoDBClient) GetCluster(clusterName string) (types.Cluster, error
 	var result types.Cluster
 	err := mdbcl.Collection.FindOne(mdbcl.Context, filter).Decode(&result)
 	if err != nil {
-		return types.Cluster{}, err
+		return types.Cluster{}, fmt.Errorf("error getting cluster %s: %s", clusterName, err)
 	}
 
 	return result, nil
@@ -82,7 +84,7 @@ func (mdbcl *MongoDBClient) GetClusters() ([]types.Cluster, error) {
 	var results []types.Cluster
 	cursor, err := mdbcl.Collection.Find(mdbcl.Context, bson.D{})
 	if err != nil {
-		return []types.Cluster{}, err
+		return []types.Cluster{}, fmt.Errorf("error getting clusters: %s", err)
 	}
 
 	for cursor.Next(mdbcl.Context) {
@@ -115,7 +117,7 @@ func (mdbcl *MongoDBClient) InsertCluster(cl types.Cluster) error {
 			// Create if entry does not exist
 			insert, err := mdbcl.Collection.InsertOne(mdbcl.Context, cl)
 			if err != nil {
-				return err
+				return fmt.Errorf("error inserting cluster %s: %s", cl.ClusterName, err)
 			}
 			log.Info(insert)
 		}
@@ -133,7 +135,7 @@ func (mdbcl *MongoDBClient) UpdateCluster(clusterName string, field string, valu
 	var result types.Cluster
 	err := mdbcl.Collection.FindOne(mdbcl.Context, filter).Decode(&result)
 	if err != nil {
-		return err
+		return fmt.Errorf("error finding cluster %s: %s", clusterName, err)
 	}
 
 	// Update
@@ -141,10 +143,132 @@ func (mdbcl *MongoDBClient) UpdateCluster(clusterName string, field string, valu
 	update := bson.D{{"$set", bson.D{{field, value}}}}
 	resp, err := mdbcl.Collection.UpdateOne(mdbcl.Context, filter, update)
 	if err != nil {
-		return err
+		return fmt.Errorf("error updating cluster %s: %s", clusterName, err)
 	}
 
 	log.Infof("cluster updated: %v", resp.ModifiedCount)
+
+	return nil
+}
+
+// Backups
+const clusterExportsPath = "/tmp/api/cluster/export"
+const clusterImportsPath = "/tmp/api/cluster/import"
+
+// Export parses the contents of a single cluster to a local file
+func (mdbcl *MongoDBClient) Export(clusterName string) error {
+	var localFilePath = fmt.Sprintf("%s/%s.json", clusterExportsPath, clusterName)
+	var remoteFilePath = fmt.Sprintf("%s.json", clusterName)
+
+	// Find
+	filter := bson.D{{"cluster_name", clusterName}}
+	var result types.Cluster
+	err := mdbcl.Collection.FindOne(mdbcl.Context, filter).Decode(&result)
+	if err != nil {
+		return err
+	}
+
+	// Format file for cluster dump
+	// Verify export directory exists
+	if _, err := os.Stat(clusterExportsPath); os.IsNotExist(err) {
+		log.Info("cluster exports directory does not exist, creating")
+		err := os.MkdirAll(clusterExportsPath, 0777)
+		if err != nil {
+			return err
+		}
+	}
+
+	file, _ := json.MarshalIndent(result, "", " ")
+	_ = os.WriteFile(localFilePath, file, 0644)
+
+	// Put file containing cluster dump in object storage
+	err = objectStorage.PutClusterObject(
+		&types.StateStoreCredentials{
+			AccessKeyID:     "UD2IKJKQ6PQ9YRFN1KUM",
+			SecretAccessKey: "AESQOlwOyjtfRzzQlLY4UVSpcXAIkjeWeYCafKy7",
+			Name:            "k1-state-store-feedkray-com-klpf61",
+		},
+		&types.StateStoreDetails{
+			Name:     "k1-state-store-feedkray-com-klpf61",
+			Hostname: "objectstore.nyc1.civo.com",
+		},
+		&types.PushBucketObject{
+			LocalFilePath:  localFilePath,
+			RemoteFilePath: remoteFilePath,
+			ContentType:    "application/json",
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("successfully exported cluster %s to object storage bucket", clusterName)
+
+	err = os.Remove(localFilePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Restore retrieves a target cluster's database export from a state storage bucket and
+// attempts to insert the parsed cluster object into the database
+func (mdbcl *MongoDBClient) Restore(clusterName string) error {
+	var cluster *types.Cluster
+	var localFilePath = fmt.Sprintf("%s/%s.json", clusterImportsPath, clusterName)
+	var remoteFilePath = fmt.Sprintf("%s.json", clusterName)
+
+	// Verify import directory exists
+	if _, err := os.Stat(clusterImportsPath); os.IsNotExist(err) {
+		log.Info("cluster imports directory does not exist, creating")
+		err := os.MkdirAll(clusterImportsPath, 0777)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Retrieve the object from state storage bucket
+	err := objectStorage.GetClusterObject(
+		&types.StateStoreCredentials{
+			AccessKeyID:     "UD2IKJKQ6PQ9YRFN1KUM",
+			SecretAccessKey: "AESQOlwOyjtfRzzQlLY4UVSpcXAIkjeWeYCafKy7",
+			Name:            "k1-state-store-feedkray-com-klpf61",
+		},
+		&types.StateStoreDetails{
+			Name:     "k1-state-store-feedkray-com-klpf61",
+			Hostname: "objectstore.nyc1.civo.com",
+		},
+		clusterName,
+		localFilePath,
+		remoteFilePath,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Marshal file contents into cluster struct
+	fileContents, err := os.ReadFile(localFilePath)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(fileContents, &cluster)
+	if err != nil {
+		return fmt.Errorf("target file %s does not appear to be valid json: %s", localFilePath, err)
+	}
+
+	// Insert the cluster into the target database
+	err = mdbcl.InsertCluster(*cluster)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("successfully restored cluster %s to database", clusterName)
+
+	err = os.Remove(localFilePath)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/db/mongo.go
+++ b/internal/db/mongo.go
@@ -183,15 +183,8 @@ func (mdbcl *MongoDBClient) Export(clusterName string) error {
 
 	// Put file containing cluster dump in object storage
 	err = objectStorage.PutClusterObject(
-		&types.StateStoreCredentials{
-			AccessKeyID:     "UD2IKJKQ6PQ9YRFN1KUM",
-			SecretAccessKey: "AESQOlwOyjtfRzzQlLY4UVSpcXAIkjeWeYCafKy7",
-			Name:            "k1-state-store-feedkray-com-klpf61",
-		},
-		&types.StateStoreDetails{
-			Name:     "k1-state-store-feedkray-com-klpf61",
-			Hostname: "objectstore.nyc1.civo.com",
-		},
+		result.StateStoreCredentials,
+		result.StateStoreDetails,
 		&types.PushBucketObject{
 			LocalFilePath:  localFilePath,
 			RemoteFilePath: remoteFilePath,
@@ -230,15 +223,8 @@ func (mdbcl *MongoDBClient) Restore(clusterName string) error {
 
 	// Retrieve the object from state storage bucket
 	err := objectStorage.GetClusterObject(
-		&types.StateStoreCredentials{
-			AccessKeyID:     "UD2IKJKQ6PQ9YRFN1KUM",
-			SecretAccessKey: "AESQOlwOyjtfRzzQlLY4UVSpcXAIkjeWeYCafKy7",
-			Name:            "k1-state-store-feedkray-com-klpf61",
-		},
-		&types.StateStoreDetails{
-			Name:     "k1-state-store-feedkray-com-klpf61",
-			Hostname: "objectstore.nyc1.civo.com",
-		},
+		result.StateStoreCredentials,
+		result.StateStoreDetails,
 		clusterName,
 		localFilePath,
 		remoteFilePath,

--- a/internal/objectStorage/objectStorage.go
+++ b/internal/objectStorage/objectStorage.go
@@ -28,7 +28,7 @@ func PutBucketObject(cr *types.StateStoreCredentials, d *types.StateStoreDetails
 		Secure: true,
 	})
 	if err != nil {
-		return fmt.Errorf("error initializing minio client for civo: %s", err)
+		return fmt.Errorf("error initializing minio client: %s", err)
 	}
 
 	object, err := os.Open(obj.LocalFilePath)
@@ -61,7 +61,7 @@ func PutClusterObject(cr *types.StateStoreCredentials, d *types.StateStoreDetail
 		Secure: true,
 	})
 	if err != nil {
-		return fmt.Errorf("error initializing minio client for civo: %s", err)
+		return fmt.Errorf("error initializing minio client: %s", err)
 	}
 
 	// Reference for cluster object output file

--- a/internal/objectStorage/objectStorage.go
+++ b/internal/objectStorage/objectStorage.go
@@ -1,0 +1,132 @@
+/*
+Copyright (C) 2021-2023, Kubefirst
+
+This program is licensed under MIT.
+See the LICENSE file for more details.
+*/
+package objectStorage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/kubefirst/kubefirst-api/internal/types"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	log "github.com/sirupsen/logrus"
+)
+
+// PutBucketObject
+func PutBucketObject(cr *types.StateStoreCredentials, d *types.StateStoreDetails, obj *types.PushBucketObject) error {
+	ctx := context.Background()
+
+	// Initialize minio client object.
+	minioClient, err := minio.New(d.Hostname, &minio.Options{
+		Creds:  credentials.NewStaticV4(cr.AccessKeyID, cr.SecretAccessKey, ""),
+		Secure: true,
+	})
+	if err != nil {
+		return fmt.Errorf("error initializing minio client for civo: %s", err)
+	}
+
+	object, err := os.Open(obj.LocalFilePath)
+	if err != nil {
+		return err
+	}
+	defer object.Close()
+
+	objectStat, err := object.Stat()
+	if err != nil {
+		return err
+	}
+
+	n, err := minioClient.PutObject(ctx, d.Name, obj.RemoteFilePath, object, objectStat.Size(), minio.PutObjectOptions{ContentType: obj.ContentType})
+	if err != nil {
+		return err
+	}
+	log.Info("uploaded", obj.LocalFilePath, " of size: ", n, "successfully")
+
+	return nil
+}
+
+// PutClusterObject exports a cluster definition as json and places it in the target object storage bucket
+func PutClusterObject(cr *types.StateStoreCredentials, d *types.StateStoreDetails, obj *types.PushBucketObject) error {
+	ctx := context.Background()
+
+	// Initialize minio client
+	minioClient, err := minio.New(d.Hostname, &minio.Options{
+		Creds:  credentials.NewStaticV4(cr.AccessKeyID, cr.SecretAccessKey, ""),
+		Secure: true,
+	})
+	if err != nil {
+		return fmt.Errorf("error initializing minio client for civo: %s", err)
+	}
+
+	// Reference for cluster object output file
+	object, err := os.Open(obj.LocalFilePath)
+	if err != nil {
+		return fmt.Errorf("error during object local copy file lookup: %s", err)
+	}
+	defer object.Close()
+
+	objectStat, err := object.Stat()
+	if err != nil {
+		return fmt.Errorf("error during object stat: %s", err)
+	}
+
+	// Put
+	_, err = minioClient.PutObject(
+		ctx,
+		d.Name,
+		obj.RemoteFilePath,
+		object,
+		objectStat.Size(),
+		minio.PutObjectOptions{ContentType: obj.ContentType},
+	)
+	if err != nil {
+		return fmt.Errorf("error during object put: %s", err)
+	}
+	log.Infof("uploaded cluster object %s to state store bucket %s successfully", obj.LocalFilePath, d.Name)
+
+	return nil
+}
+
+// GetClusterObject exports a cluster definition as json and places it in the target object storage bucket
+func GetClusterObject(cr *types.StateStoreCredentials, d *types.StateStoreDetails, clusterName string, localFilePath string, remoteFilePath string) error {
+	ctx := context.Background()
+
+	// Initialize minio client
+	minioClient, err := minio.New(d.Hostname, &minio.Options{
+		Creds:  credentials.NewStaticV4(cr.AccessKeyID, cr.SecretAccessKey, ""),
+		Secure: true,
+	})
+	if err != nil {
+		return fmt.Errorf("error initializing minio client: %s", err)
+	}
+
+	// Get object from bucket
+	reader, err := minioClient.GetObject(ctx, d.Name, remoteFilePath, minio.GetObjectOptions{})
+	if err != nil {
+		return fmt.Errorf("error retrieving cluster object from bucket: %s", err)
+	}
+	defer reader.Close()
+
+	// Write object to local file
+	localFile, err := os.Create(localFilePath)
+	if err != nil {
+		return fmt.Errorf("error during object local copy file create: %s", err)
+	}
+	defer localFile.Close()
+
+	stat, err := reader.Stat()
+	if err != nil {
+		return fmt.Errorf("error during object stat: %s", err)
+	}
+	if _, err := io.CopyN(localFile, reader, stat.Size); err != nil {
+		return fmt.Errorf("error during object copy: %s", err)
+	}
+
+	return nil
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -27,7 +27,7 @@ func SetupRouter() *gin.Engine {
 	r.Use(cors.New(cors.Config{
 		AllowAllOrigins: true,
 		AllowMethods:    []string{"DELETE", "GET", "HEAD", "PATCH", "POST", "PUT", "OPTIONS"},
-		AllowHeaders: []string{"origin", "content-Type"},
+		AllowHeaders:    []string{"origin", "content-Type"},
 	}))
 
 	// Establish routes we don't want to log requests to
@@ -48,6 +48,8 @@ func SetupRouter() *gin.Engine {
 		v1.GET("/cluster/:cluster_name", router.GetCluster)
 		v1.DELETE("/cluster/:cluster_name", router.DeleteCluster)
 		v1.POST("/cluster/:cluster_name", router.PostCreateCluster)
+		v1.POST("/cluster/:cluster_name/export", router.PostExportCluster)
+		v1.POST("/cluster/:cluster_name/import", router.PostImportCluster)
 
 		// AWS
 		v1.GET("/aws/profiles", router.GetAWSProfiles)

--- a/internal/types/cluster.go
+++ b/internal/types/cluster.go
@@ -113,3 +113,9 @@ type PushBucketObject struct {
 	RemoteFilePath string
 	ContentType    string
 }
+
+// ImportClusterRequest
+type ImportClusterRequest struct {
+	StateStoreCredentials StateStoreCredentials
+	StateStoreDetails     StateStoreDetails
+}

--- a/internal/types/cluster.go
+++ b/internal/types/cluster.go
@@ -106,3 +106,10 @@ type StateStoreDetails struct {
 	AWSStateStoreBucket string `bson:"aws_state_store_bucket,omitempty"`
 	AWSArtifactsBucket  string `bson:"aws_artifacts_bucket,omitempty"`
 }
+
+// PushBucketObject
+type PushBucketObject struct {
+	LocalFilePath  string
+	RemoteFilePath string
+	ContentType    string
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"time"
 
@@ -50,6 +51,30 @@ func ReadFileContents(filePath string) (string, error) {
 		return "", err
 	}
 	return string(data), nil
+}
+
+// ReadFileContentType reads a file on the OS and returns its file type
+func ReadFileContentType(filePath string) (string, error) {
+	// Open File
+	f, err := os.Open(filePath)
+	if err != nil {
+		log.Error(err)
+	}
+	defer f.Close()
+
+	// Only the first 512 bytes are used to sniff the content type.
+	buffer := make([]byte, 512)
+
+	_, err = f.Read(buffer)
+	if err != nil {
+		return "", err
+	}
+
+	// Use the net/http package's handy DectectContentType function. Always returns a valid
+	// content-type by returning "application/octet-stream" if no others seemed to match.
+	contentType := http.DetectContentType(buffer)
+
+	return contentType, nil
 }
 
 // RemoveFromSlice accepts T as a comparable slice and removed the index at


### PR DESCRIPTION
adds new routes for handling exports and imports. export only requires the cluster name in the path since it can use existing state store credentials in the existing record.

import requires passing in auth:

```bash
> curl -X POST http://localhost:8081/api/v1/cluster/kf-api-scott-test-31/export

> curl -X POST http://localhost:8081/api/v1/cluster/kf-api-scott-test-31/import -H "Content-Type: application/json" -d '{"stateStoreCredentials": {"accessKeyID": "1234", "secretAccessKey": "1234"}, "stateStoreDetails": {"hostname": "objectstore.nyc1.civo.com","name": "k1-state-store-blah"}}'
```