### PR TITLE
feat: add support for envFrom in helm chart deployment

### DIFF
--- a/charts/kubefirst-api/templates/deployment.yaml
+++ b/charts/kubefirst-api/templates/deployment.yaml
@@ -29,11 +29,17 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.env }}
           env:
-            {{- range $name, $item := .Values.env }}
-            - name: {{ $name }}
-              {{- $item | toYaml | nindent 14 }}
+            {{- range $envVar := .Values.env }}
+            - name: {{ $envVar.name }}
+              value: {{ $envVar.value }}
             {{- end }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/kubefirst-api/values.yaml
+++ b/charts/kubefirst-api/values.yaml
@@ -82,3 +82,4 @@ tolerations: []
 affinity: {}
 
 env: []
+envFrom: []


### PR DESCRIPTION
adds env support to kubefirst api helm chart
example `values.yaml`
```
env:
  - name: "FOO"
    value: "BAR"
  - name: "BAR"
    value: "BAR"
  - name: "CCC"
    value: "BAR"
envFrom:
  - secretRef: 
      name: my-secret
```
rendered helm chart
```
      containers:
        - name: kubefirst-api
          env:
            - name: FOO
              value: BAR
            - name: BAR
              value: BAR
            - name: CCC
              value: BAR
          envFrom:
            - secretRef:
                name: my-secret
          securityContext:
```
empty `values.yaml` 
```
env: []
envFrom: []
```
rendered helm chart
```
      containers:
        - name: kubefirst-api
          securityContext:
            {}

```