### PR TITLE
feat: wait for svc sync

### DIFF
--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -64,13 +64,6 @@ func (clctrl *ClusterController) RunUsersTerraform() error {
 		telemetryShim.Transmit(clctrl.UseTelemetry, segmentClient, segment.MetricUsersTerraformApplyStarted, "")
 		log.Info("applying users terraform")
 
-		var vaultRootToken string
-		secData, err := k8s.ReadSecretV2(kcfg.Clientset, "vault", "vault-unseal-secret")
-		if err != nil {
-			return err
-		}
-		vaultRootToken = secData["root-token"]
-
 		tfEnvs := map[string]string{}
 		var tfEntrypoint, terraformClient string
 


### PR DESCRIPTION
post - `api/v1/services/:cluster_name/:service_name` is now blocking and will wait for the application to be created and return healthy status before returning a `200`