### PR TITLE
fix: cleanup some output

### DIFF
--- a/internal/db/clusters.go
+++ b/internal/db/clusters.go
@@ -46,6 +46,9 @@ func (mdbcl *MongoDBClient) GetCluster(clusterName string) (types.Cluster, error
 	var result types.Cluster
 	err := mdbcl.ClustersCollection.FindOne(mdbcl.Context, filter).Decode(&result)
 	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return types.Cluster{}, fmt.Errorf("cluster not found")
+		}
 		return types.Cluster{}, fmt.Errorf("error getting cluster %s: %s", clusterName, err)
 	}
 

--- a/internal/db/services.go
+++ b/internal/db/services.go
@@ -24,14 +24,13 @@ func (mdbcl *MongoDBClient) CreateClusterServiceList(cl *types.Cluster) error {
 		// This error means your query did not match any documents.
 		if err == mongo.ErrNoDocuments {
 			// Create if entry does not exist
-			insert, err := mdbcl.ServicesCollection.InsertOne(mdbcl.Context, types.ClusterServiceList{
+			_, err := mdbcl.ServicesCollection.InsertOne(mdbcl.Context, types.ClusterServiceList{
 				ClusterName: cl.ClusterName,
 				Services:    []types.Service{},
 			})
 			if err != nil {
 				return fmt.Errorf("error inserting cluster service list for cluster %s: %s", cl.ClusterName, err)
 			}
-			log.Info(insert)
 		}
 	} else {
 		log.Infof("cluster service list record for %s already exists - skipping", cl.ClusterName)


### PR DESCRIPTION
- remove useless log after service record is initially created
- return "cluster not found" instead of generic mongo error when a cluster doesn't exist for the single cluster endpoint