### PR TITLE
fix: retry mechanism

### DIFF
--- a/internal/router/api/v1/cluster.go
+++ b/internal/router/api/v1/cluster.go
@@ -238,6 +238,16 @@ func PostCreateCluster(c *gin.Context) {
 		}
 	}
 
+	//Retry mechanism
+	if cluster.ClusterName != "" {
+		//Assign cloud and git credentials
+		clusterDefinition.AWSAuth = cluster.AWSAuth
+		clusterDefinition.CivoAuth = cluster.CivoAuth
+		clusterDefinition.VultrAuth = cluster.VultrAuth
+		clusterDefinition.DigitaloceanAuth = cluster.DigitaloceanAuth
+		clusterDefinition.GitAuth = cluster.GitAuth
+	}
+
 	// Determine authentication type
 	inCluster := false
 	useSecretForAuth := false


### PR DESCRIPTION
- Console is persisting the state and is not storing sensitive information like cloud and git credentials, so this fix the retry button, is getting the credentials from the database instead of the body params