### PR TITLE
Fix: external dns

### DIFF
--- a/extensions/aws/secrets.go
+++ b/extensions/aws/secrets.go
@@ -23,15 +23,16 @@ import (
 func BootstrapAWSMgmtCluster(
 	clientset *kubernetes.Clientset,
 	cl *types.Cluster,
-	config *providerConfig.ProviderConfig,
+	destinationGitopsRepoURL string,
 	awsClient *aws.AWSConfiguration,
 ) error {
+	
 
 	err := providerConfig.BootstrapMgmtCluster(
 		clientset,
 		cl.GitProvider,
 		cl.GitAuth.User,
-		config.DestinationGitopsRepoURL,
+		destinationGitopsRepoURL,
 		cl.GitProtocol,
 		cl.CloudflareAuth.Token,
 		"",
@@ -42,6 +43,7 @@ func BootstrapAWSMgmtCluster(
 	)
 	if err != nil {
 		log.Fatal().Msgf("error in central function to create secrets: %s", err)
+		return err
 	}
 
 	// Create secrets

--- a/extensions/civo/secrets.go
+++ b/extensions/civo/secrets.go
@@ -19,13 +19,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func BootstrapCivoMgmtCluster(clientset *kubernetes.Clientset, cl *types.Cluster, config *providerConfig.ProviderConfig) error {
+func BootstrapCivoMgmtCluster(clientset *kubernetes.Clientset, cl *types.Cluster, destinationGitopsRepoURL string) error {
 
 	err := providerConfig.BootstrapMgmtCluster(
 		clientset,
 		cl.GitProvider,
 		cl.GitAuth.User,
-		config.DestinationGitopsRepoURL,
+		destinationGitopsRepoURL,
 		cl.GitProtocol,
 		cl.CloudflareAuth.Token,
 		cl.CivoAuth.Token,
@@ -36,6 +36,7 @@ func BootstrapCivoMgmtCluster(clientset *kubernetes.Clientset, cl *types.Cluster
 	)
 	if err != nil {
 		log.Fatal().Msgf("error in central function to create secrets: %s", err)
+		return err
 	}
 
 	// Create secrets

--- a/extensions/digitalocean/secrets.go
+++ b/extensions/digitalocean/secrets.go
@@ -19,13 +19,14 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func BootstrapDigitaloceanMgmtCluster(clientset *kubernetes.Clientset, cl *types.Cluster, config *providerConfig.ProviderConfig) error {
+func BootstrapDigitaloceanMgmtCluster(clientset *kubernetes.Clientset, cl *types.Cluster, destinationGitopsRepoURL string) error {
+	
 
 	err := providerConfig.BootstrapMgmtCluster(
 		clientset,
 		cl.GitProvider,
 		cl.GitAuth.User,
-		config.DestinationGitopsRepoURL,
+		destinationGitopsRepoURL,
 		cl.GitProtocol,
 		cl.CloudflareAuth.Token,
 		cl.DigitaloceanAuth.Token,
@@ -36,6 +37,7 @@ func BootstrapDigitaloceanMgmtCluster(clientset *kubernetes.Clientset, cl *types
 	)
 	if err != nil {
 		log.Fatal().Msgf("error in central function to create secrets: %s", err)
+		return err
 	}
 
 	// Create secrets

--- a/extensions/google/secrets.go
+++ b/extensions/google/secrets.go
@@ -21,14 +21,14 @@ import (
 func BootstrapGoogleMgmtCluster(
 	clientset *kubernetes.Clientset,
 	cl *types.Cluster,
-	config *providerConfig.ProviderConfig,
+	destinationGitopsRepoURL string,
 ) error {
 
 	err := providerConfig.BootstrapMgmtCluster(
 		clientset,
 		cl.GitProvider,
 		cl.GitAuth.User,
-		config.DestinationGitopsRepoURL,
+		destinationGitopsRepoURL,
 		cl.GitProtocol,
 		cl.CloudflareAuth.Token,
 		cl.GoogleAuth.KeyFile, //Google has no authentication method because we use roles
@@ -39,6 +39,7 @@ func BootstrapGoogleMgmtCluster(
 	)
 	if err != nil {
 		log.Fatal().Msgf("error in central function to create secrets: %s", err)
+		return err
 	}
 	// Create secrets
 	createSecrets := []*v1.Secret{}

--- a/extensions/vultr/secrets.go
+++ b/extensions/vultr/secrets.go
@@ -19,13 +19,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func BootstrapVultrMgmtCluster(clientset *kubernetes.Clientset, cl *types.Cluster, config *providerConfig.ProviderConfig) error {
+func BootstrapVultrMgmtCluster(clientset *kubernetes.Clientset, cl *types.Cluster, destinationGitopsRepoURL string) error {
 
 	err := providerConfig.BootstrapMgmtCluster(
 		clientset,
 		cl.GitProvider,
 		cl.GitAuth.User,
-		config.DestinationGitopsRepoURL,
+		destinationGitopsRepoURL,
 		cl.GitProtocol,
 		cl.CloudflareAuth.Token,
 		cl.VultrAuth.Token,
@@ -36,6 +36,7 @@ func BootstrapVultrMgmtCluster(clientset *kubernetes.Clientset, cl *types.Cluste
 	)
 	if err != nil {
 		log.Fatal().Msgf("error in central function to create secrets: %s", err)
+		return err
 	}
 	// Create secrets
 	createSecrets := []*v1.Secret{}

--- a/internal/controller/git.go
+++ b/internal/controller/git.go
@@ -161,9 +161,6 @@ func (clctrl *ClusterController) GetRepoURL() (string, error) {
 			// Update the urls in the cluster for gitlab parent groups
 			clctrl.ProviderConfig.DestinationGitopsRepoHttpsURL = fmt.Sprintf("https://gitlab.com/%s/gitops.git", gitlabClient.ParentGroupPath)
 			clctrl.ProviderConfig.DestinationMetaphorRepoHttpsURL = fmt.Sprintf("https://gitlab.com/%s/metaphor.git", gitlabClient.ParentGroupPath)
-			// Return the url used for detokenization
-			destinationGitopsRepoURL = clctrl.ProviderConfig.DestinationGitopsRepoHttpsURL
-
 		default:
 			// Update the urls in the cluster for gitlab parent group
 			clctrl.ProviderConfig.DestinationGitopsRepoGitURL = fmt.Sprintf("git@gitlab.com:%s/gitops.git", gitlabClient.ParentGroupPath)


### PR DESCRIPTION
Fixes the mismatch between the centralized secrets function and the https/ssh getRepoURL function. 

Also, updates the translation of the auth secrets to the correct env key name for external dns on a case  by case basis.