### PR TITLE
Don't let users install applications from the GitOps catalog that won't work on k3d

### DIFF
--- a/internal/db/gitopsCatalog.go
+++ b/internal/db/gitopsCatalog.go
@@ -28,6 +28,17 @@ func (mdbcl *MongoDBClient) GetGitopsCatalogApps() (types.GitopsCatalogApps, err
 	return result, nil
 }
 
+func k3dCatalogApps(apps []types.GitopsCatalogApp) []types.GitopsCatalogApp {
+	var k3dApps []types.GitopsCatalogApp
+	for _, app := range apps {
+		worksOnK3D := app.K3D == nil
+		if worksOnK3D {
+			k3dApps = append(k3dApps, app)
+		}
+	}
+	return k3dApps
+}
+
 // UpdateGitopsCatalogApps
 func (mdbcl *MongoDBClient) UpdateGitopsCatalogApps() error {
 	mpapps, err := gitopsCatalog.ReadActiveApplications()
@@ -36,7 +47,7 @@ func (mdbcl *MongoDBClient) UpdateGitopsCatalogApps() error {
 	}
 
 	filter := bson.D{{Key: "name", Value: "gitops_catalog_application_list"}}
-	update := bson.D{{Key: "$set", Value: bson.D{{Key: "apps", Value: mpapps.Apps}}}}
+	update := bson.D{{Key: "$set", Value: bson.D{{Key: "apps", Value: k3dCatalogApps(mpapps.Apps)}}}}
 	opts := options.Update().SetUpsert(true)
 
 	_, err = mdbcl.GitopsCatalogCollection.UpdateOne(mdbcl.Context, filter, update, opts)

--- a/internal/types/gitopsCatalog.go
+++ b/internal/types/gitopsCatalog.go
@@ -20,6 +20,7 @@ type GitopsCatalogApp struct {
 	ImageURL    string                      `bson:"image_url" json:"image_url" yaml:"imageUrl"`
 	Description string                      `bson:"description" json:"description" yaml:"description"`
 	Categories  []string                    `bson:"categories" json:"categories" yaml:"categories"`
+	K3D         *bool                       `bson:"k3d" json:"k3d" yaml:"k3d"`
 }
 
 // GitopsCatalogAppSecretKey describes a required secret value when creating a


### PR DESCRIPTION
[Linked issue](https://github.com/kubefirst/kubefirst/issues/1810) #1810

[Catalog PR](https://github.com/kubefirst/gitops-catalog/pull/36)

**scope**
- don't load the applications with `k3d` set to `false` to console

**test**

I've tested this in the console on localhost. The observability apps don't show DataDog anymore (the only catalog app so far that doesn't work on k3d)

![Screenshot 2023-10-17 at 22 43 06](https://github.com/kubefirst/kubefirst-api/assets/2116354/e4473360-464a-4b5c-a70d-5e06a46e939a)


