### PR TITLE
add aws cli to api image for aws terraform executions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=builder /build/kubefirst-api /
 COPY --from=builder /build/docs /docs
 
 RUN apk update && \
-  apk add git openssh 
+  apk add git openssh aws-cli
 
 RUN mkdir -p /root/.ssh
 RUN ssh-keyscan github.com >> /root/.ssh/known_hosts


### PR DESCRIPTION
adds the aws cli v2 to the final image so the binary is available to terraform for authentication purposes