### PR TITLE
fix: handle error when writing google secrets to vault

### DIFF
--- a/internal/controller/vault.go
+++ b/internal/controller/vault.go
@@ -350,7 +350,10 @@ func (clctrl *ClusterController) WriteVaultSecrets() error {
 		if err != nil {
 			log.Fatal().Msgf("error getting home path: %s", err)
 		}
-		writeGoogleSecrets(homeDir, vaultClient)
+		if err := writeGoogleSecrets(homeDir, vaultClient); err != nil {
+			log.Error().Msgf("error writing Google secrets to vault: %s", err)
+			return err
+		}
 		log.Info().Msg("successfully wrote google specific secrets to vault")
 	}
 


### PR DESCRIPTION
The `writeGoogleSecrets` function returns an error which wasn't being handled. This adds in this check.