### PR TITLE
fix: pass SSH private key content as environment variable for K3s

### DIFF
--- a/extensions/k3s/env.go
+++ b/extensions/k3s/env.go
@@ -30,6 +30,7 @@ func readVaultTokenFromSecret(clientset *kubernetes.Clientset) string {
 }
 
 func GetK3sTerraformEnvs(envs map[string]string, cl *pkgtypes.Cluster) map[string]string {
+	envs["TF_VAR_ssh_private_key"] = cl.K3sAuth.K3sSshPrivateKey
 	envs["AWS_ACCESS_KEY_ID"] = cl.StateStoreCredentials.AccessKeyID
 	envs["AWS_SECRET_ACCESS_KEY"] = cl.StateStoreCredentials.SecretAccessKey
 	envs["AWS_SESSION_TOKEN"] = "" // allows for debugging

--- a/internal/controller/cluster.go
+++ b/internal/controller/cluster.go
@@ -105,7 +105,6 @@ func (clctrl *ClusterController) CreateCluster() error {
 		clctrl.Cluster.CloudTerraformApplyCheck = true
 		clctrl.Cluster.CloudTerraformApplyFailedCheck = false
 		err = secrets.UpdateCluster(clctrl.KubernetesClient, clctrl.Cluster)
-
 		if err != nil {
 			return err
 		}
@@ -264,7 +263,6 @@ func (clctrl *ClusterController) CreateTokens(kind string) interface{} {
 			gitopsTemplateTokens.K3sServersPrivateIps = clctrl.K3sAuth.K3sServersPrivateIps
 			gitopsTemplateTokens.K3sServersPublicIps = clctrl.K3sAuth.K3sServersPublicIps
 			gitopsTemplateTokens.SshUser = clctrl.K3sAuth.K3sSshUser
-			gitopsTemplateTokens.SshPrivateKey = clctrl.K3sAuth.K3sSshPrivateKey
 			gitopsTemplateTokens.K3sServersArgs = clctrl.K3sAuth.K3sServersArgs
 		}
 

--- a/pkg/providerConfigs/detokenize.go
+++ b/pkg/providerConfigs/detokenize.go
@@ -127,7 +127,6 @@ func detokenizeGitops(path string, tokens *GitopsDirectoryValues, gitProtocol st
 					newContents = strings.Replace(newContents, "<K3S_SERVERS_ARGS>", terraformServersArgsList, -1)
 
 					newContents = strings.Replace(newContents, "<SSH_USER>", tokens.SshUser, -1)
-					newContents = strings.Replace(newContents, "<SSH_PRIVATE_KEY_PATH>", tokens.SshPrivateKey, -1)
 				}
 				newContents = strings.Replace(newContents, "<ARGOCD_INGRESS_URL>", tokens.ArgoCDIngressURL, -1)
 				newContents = strings.Replace(newContents, "<ARGOCD_INGRESS_NO_HTTP_URL>", tokens.ArgoCDIngressNoHTTPSURL, -1)


### PR DESCRIPTION
hotFix : #https://github.com/kubefirst/gitops-template/pull/758


because i passe the sshkey file path before ( which work on local) but not on prod mode due to cluster 0 stuff

so we pass the content directly to cli

`--ssh-private-key $(cat ~/.ssh/id_ed....)`