### PR TITLE
fix : timeout issue for argocd and vault for public clouds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,45 @@
 FROM golang:alpine AS builder
 
 ENV GO111MODULE=on \
-  CGO_ENABLED=0 \
-  GOOS=linux \
-  GOARCH=amd64
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
 
 WORKDIR /build
 
-# Download go dependencies
 COPY go.mod .
 COPY go.sum .
+
 RUN go mod download
 
-# Copy into the container
 COPY . .
 
-# Build the application
 RUN go build -o kubefirst-api .
 
-# Build final image using nothing but the binary
 FROM alpine:3.18.2
+
+RUN apk update && \
+    apk add --no-cache \
+        git \
+        openssh \
+        aws-cli \
+        curl
+
+RUN mkdir -p /root/.ssh \
+    && ssh-keyscan github.com >> /root/.ssh/known_hosts \
+    && ssh-keyscan gitlab.com >> /root/.ssh/known_hosts
+
+
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+    && chmod +x ./kubectl \
+    && mv ./kubectl /usr/local/bin/kubectl
+
 
 COPY --from=builder /build/kubefirst-api /
 COPY --from=builder /build/docs /docs
 
-RUN apk update && \
-  apk add git openssh aws-cli
-
-RUN mkdir -p /root/.ssh
-RUN ssh-keyscan github.com >> /root/.ssh/known_hosts
-RUN ssh-keyscan gitlab.com >> /root/.ssh/known_hosts
 
 EXPOSE 8081
 
-# Command to run
+
 ENTRYPOINT ["/kubefirst-api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,17 +29,13 @@ RUN mkdir -p /root/.ssh \
     && ssh-keyscan github.com >> /root/.ssh/known_hosts \
     && ssh-keyscan gitlab.com >> /root/.ssh/known_hosts
 
-
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin/kubectl
 
-
 COPY --from=builder /build/kubefirst-api /
 COPY --from=builder /build/docs /docs
 
-
 EXPOSE 8081
-
 
 ENTRYPOINT ["/kubefirst-api"]

--- a/internal/controller/argocd.go
+++ b/internal/controller/argocd.go
@@ -178,7 +178,7 @@ func (clctrl *ClusterController) DeployRegistryApplication() error {
 		if err != nil {
 			return err
 		}
-		// log.Info().Msg(kcfg.RestConfig)
+		
 		log.Info().Msg("applying the registry application to argocd")
 
 		registryURL, err := clctrl.GetRepoURL()

--- a/internal/controller/argocd.go
+++ b/internal/controller/argocd.go
@@ -9,6 +9,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"os/exec"
+	"time"	
 
 	argocdapi "github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned"
 	awsext "github.com/kubefirst/kubefirst-api/extensions/aws"
@@ -176,7 +178,7 @@ func (clctrl *ClusterController) DeployRegistryApplication() error {
 		if err != nil {
 			return err
 		}
-
+		// log.Info().Msg(kcfg.RestConfig)
 		log.Info().Msg("applying the registry application to argocd")
 
 		registryURL, err := clctrl.GetRepoURL()
@@ -196,7 +198,36 @@ func (clctrl *ClusterController) DeployRegistryApplication() error {
 			registryPath,
 		)
 
-		_, _ = argocdClient.ArgoprojV1alpha1().Applications("argocd").Create(context.Background(), registryApplicationObject, metav1.CreateOptions{})
+
+		cmdStr := fmt.Sprintf("kubectl --kubeconfig=%s rollout restart -n argocd deploy/argocd-applicationset-controller", clctrl.ProviderConfig.Kubeconfig)
+
+		cmd := exec.Command("/bin/sh", "-c", cmdStr)
+
+		err = cmd.Run()
+		if err != nil {
+			fmt.Printf("Error executing kubectl command: %v\n", err)
+			return err
+		}
+
+
+		retryAttempts := 2
+		for attempt := 1; attempt <= retryAttempts; attempt++ {
+			log.Info().Msgf("Attempt #%d to create Argo CD application...\n", attempt)
+
+			app, err := argocdClient.ArgoprojV1alpha1().Applications("argocd").Create(context.Background(), registryApplicationObject, metav1.CreateOptions{})
+			if err != nil {
+				if attempt == retryAttempts {
+					return err
+				}
+				log.Info().Msgf("Error creating Argo CD application on attempt number #%d: %v\n", attempt, err)
+				time.Sleep(5 * time.Second)
+				continue 
+			}
+
+			log.Info().Msgf("Argo CD application created successfully on attempt #%d: %s\n", attempt, app.Name)
+			break 
+		}
+
 
 		telemetry.SendEvent(clctrl.TelemetryEvent, telemetry.CreateRegistryCompleted, "")
 


### PR DESCRIPTION
To resolve the issue where the argocd-controller starts before the argo-cd server and encounters a missing secret key error, I've added a function to reload it: