### PR TITLE
fix: update eks in-cluster authentication to use web identify files

### DIFF
--- a/internal/router/api/v1/region.go
+++ b/internal/router/api/v1/region.go
@@ -81,7 +81,6 @@ func PostRegions(c *gin.Context) {
 					regionListRequest.AWSAuth.SessionToken,
 				),
 			}
-
 		}
 
 		regions, err := awsConf.GetRegions(regionListRequest.CloudRegion)

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -3,12 +3,10 @@ package aws
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	awsinternal "github.com/kubefirst/kubefirst-api/internal/aws"
 	"github.com/rs/zerolog/log"
 )
@@ -17,22 +15,12 @@ func NewEKSServiceAccountClientV1() aws.Config {
 	// variables are automatically available in the pod through EKS
 	region := os.Getenv("AWS_REGION")
 	roleArn := os.Getenv("AWS_ROLE_ARN")
-	tokenFilePath := os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")
 
-	token, err := ioutil.ReadFile(tokenFilePath)
-	if err != nil {
-		panic(err.Error())
-	}
 	fmt.Println(fmt.Sprintf("authenticating as role arn: %s from service account", roleArn))
 
 	awsClient, err := config.LoadDefaultConfig(
 		context.Background(),
 		config.WithRegion(region),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			string(token),
-			"",
-			string(token),
-		)),
 	)
 	if err != nil {
 		log.Error().Msg("unable to create aws client")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The previous #288 installation doesn't seem to work because there's no `secret` specified in the `credentials.NewStaticCredentialsProvider` call. I don't fully understand the reasons why this was changed because the envvar `AWS_WEB_IDENTITY_TOKEN_FILE` is one of the documented ways of authenticating - https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials

This meant that the `/regions/aws` call always returns the error `failed to refresh cached credentials, static credentials are empty`.

@jarededwards I'd like to know if there is something I've misinterpreted in here. I also can't find any other use of the `aws.NewEKSServiceAccountClientV1()` call in the API, so I think it's safe to use.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- In your `gitops` repo, go to `/registry/clusters/<cluster-name>/components/kubefirst/console.yaml`
- In `spec.helm.values`, update your `kubefirst-api` to include the `image.api.repository` and `image.api.tag` below
  ```yaml
  kubefirst-api:
    image:
      api:
        repository: ttl.sh/90df18fd-62d4-4cdc-8389-05364e3e4c48
        tag: 24h
  ```

**NB.** I've built the `kubefirst-api` locally and pushed to [ttl.sh](https://ttl.sh/). This will expire at some point on 2024-07-23 (approx 09:00 UTC) so you may need to rebuild. Do that by running:

```shell
IMAGE_NAME=$(uuidgen)
docker build -t ttl.sh/${IMAGE_NAME}:24h .
docker push ttl.sh/${IMAGE_NAME}:24h
```

You can then update the `image.api.repository` value in the `console.yaml`