### PR TITLE
update prehook job to use namespace override

### DIFF
--- a/charts/kubefirst-api/templates/create-secret-job.yaml
+++ b/charts/kubefirst-api/templates/create-secret-job.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}-bootstrap
-  namespace: {{ .Release.Name }}
+  namespace: {{ default kubefirst .Values.prehookJob.namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
@@ -15,7 +15,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}-bootstrap
-  namespace: {{ .Release.Name }}
+  namespace: {{ default kubefirst .Values.prehookJob.namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
@@ -36,7 +36,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}-bootstrap
-  namespace: {{ .Release.Name }}
+  namespace: {{ default kubefirst .Values.prehookJob.namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
@@ -48,7 +48,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubefirst-api.fullname" . }}-bootstrap
-    namespace: {{ .Release.Name }}
+    namespace: {{ default kubefirst .Values.prehookJob.namespace }}
 {{- end }}
 ---
 {{- if not .Values.existingSecret }}
@@ -56,7 +56,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}-bootstrap
-  namespace: {{ .Release.Name }}
+  namespace: {{ default kubefirst .Values.prehookJob.namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"

--- a/charts/kubefirst-api/templates/create-secret-job.yaml
+++ b/charts/kubefirst-api/templates/create-secret-job.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}-bootstrap
-  namespace: {{ default kubefirst .Values.prehookJob.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
@@ -15,7 +15,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}-bootstrap
-  namespace: {{ default kubefirst .Values.prehookJob.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
@@ -36,7 +36,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}-bootstrap
-  namespace: {{ default kubefirst .Values.prehookJob.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
@@ -48,7 +48,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubefirst-api.fullname" . }}-bootstrap
-    namespace: {{ default kubefirst .Values.prehookJob.namespace }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}
 ---
 {{- if not .Values.existingSecret }}
@@ -56,7 +56,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}-bootstrap
-  namespace: {{ default kubefirst .Values.prehookJob.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
@@ -68,9 +68,11 @@ spec:
         - args:
             - create-k8s-secret
             - --namespace
-            - kubefirst
+            - {{ .Release.Namespace }}
             - --name
             - kubefirst-initial-secrets
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: public.ecr.aws/kubefirst/kubernetes-toolkit:0.1.3
           imagePullPolicy: IfNotPresent
           name: {{ include "kubefirst-api.fullname" . }}-bootstrap

--- a/charts/kubefirst-api/templates/deployment.yaml
+++ b/charts/kubefirst-api/templates/deployment.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: k1-volume
+  namespace: {{ .Release.Namespace }}
   labels:
     type: local
 spec:
@@ -22,6 +23,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: k1-pv-claim
+  namespace: {{ .Release.Namespace }}
 spec:
   storageClassName: local-path
   accessModes:
@@ -35,6 +37,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubefirst-api.labels" . | nindent 4 }}
 spec:
@@ -159,6 +162,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}-pi-hook
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubefirst-api.labels" . | nindent 4 }}
   annotations:
@@ -175,6 +179,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ include "kubefirst-api.fullname" . }}-pi-hook
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.hook.repository }}:{{ .Values.image.hook.tag }}"
           imagePullPolicy: {{ .Values.image.hook.pullPolicy }}
           args: [

--- a/charts/kubefirst-api/templates/hpa.yaml
+++ b/charts/kubefirst-api/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubefirst-api.labels" . | nindent 4 }}
 spec:

--- a/charts/kubefirst-api/templates/ingress.yaml
+++ b/charts/kubefirst-api/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubefirst-api.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/kubefirst-api/templates/rbac.yaml
+++ b/charts/kubefirst-api/templates/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubefirst-api.labels" . | nindent 4 }}
 rules:
@@ -19,6 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubefirst-api.labels" . | nindent 4 }}
 roleRef:
@@ -28,4 +30,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubefirst-api.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/kubefirst-api/templates/service.yaml
+++ b/charts/kubefirst-api/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kubefirst-api.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubefirst-api.labels" . | nindent 4 }}
 spec:

--- a/charts/kubefirst-api/templates/serviceaccount.yaml
+++ b/charts/kubefirst-api/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   name: {{ include "kubefirst-api.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubefirst-api.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/kubefirst-api/templates/tests/test-connection.yaml
+++ b/charts/kubefirst-api/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "kubefirst-api.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubefirst-api.labels" . | nindent 4 }}
   annotations:

--- a/charts/kubefirst-api/values.yaml
+++ b/charts/kubefirst-api/values.yaml
@@ -20,7 +20,7 @@ fullnameOverride: ''
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
-  createClusterRoleBinding: false
+  createClusterRoleBinding: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/kubefirst-api/values.yaml
+++ b/charts/kubefirst-api/values.yaml
@@ -7,6 +7,7 @@ replicaCount: 1
 image:
   api:
     repository: public.ecr.aws/kubefirst/kubefirst-api
+    tag: ad1462d
     pullPolicy: IfNotPresent
   hook:
     repository: public.ecr.aws/kubefirst/metrics-client
@@ -20,7 +21,7 @@ fullnameOverride: ''
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
-  createClusterRoleBinding: true
+  createClusterRoleBinding: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/kubefirst-api/values.yaml
+++ b/charts/kubefirst-api/values.yaml
@@ -7,7 +7,6 @@ replicaCount: 1
 image:
   api:
     repository: public.ecr.aws/kubefirst/kubefirst-api
-    tag: ad1462d
     pullPolicy: IfNotPresent
   hook:
     repository: public.ecr.aws/kubefirst/metrics-client


### PR DESCRIPTION
## Description
updating the prehook Job in the helm chart to allow for overriding the namespace the resources are created in as well as the namespace the secret is created in

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
fixes https://github.com/konstructio/gitops/issues/81

## How to test
`helm template kubefirst-api ./charts/kubefirst-api` 