### PR TITLE
fix clusterrole binding to match other resources

### DIFF
--- a/charts/kubefirst-api/templates/cluster-role-binding.yaml
+++ b/charts/kubefirst-api/templates/cluster-role-binding.yaml
@@ -2,13 +2,13 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: kubefirst-api-clusterrole
+  name: {{ include "kubefirst-api.fullname" . }}
   annotations:
     argocd.argoproj.io/sync-wave: '0'
 subjects:
   - kind: ServiceAccount
-    name: kubefirst-kubefirst-api
-    namespace: kubefirst
+    name: {{ include "kubefirst-api.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/charts/kubefirst-api/templates/deployment.yaml
+++ b/charts/kubefirst-api/templates/deployment.yaml
@@ -82,6 +82,8 @@ spec:
               value: {{ .Values.global.cloudProvider | default "unset" }}
             - name: CLUSTER_ID
               value: {{ .Values.global.clusterId | default $clusterId }}
+            - name: KUBE_NAMESPACE
+              value: {{ .Release.Namespace }}
             - name: CLUSTER_TYPE
               value: {{ .Values.global.clusterType | default "bootstrap" | quote }}
             - name: DOMAIN_NAME


### PR DESCRIPTION
## Description
fixes the clusterrolebinding to have the same naming convention driven by the chart

## How to test
`helm template development-kubefirst-api ./charts/kubefirst-api`
