### PR TITLE
chore: add ability to trigger publish

### DIFF
--- a/.argo/trigger.yaml
+++ b/.argo/trigger.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  namespace: argo
+spec:
+  entrypoint: main
+  serviceAccountName: argo-server
+  templates:
+    - name: main
+      steps:
+        - - name: checkout
+            templateRef:
+              name: cwft-git
+              template: checkout-with-gitops
+              clusterScope: true
+            arguments:
+              parameters:
+                - name: appName
+                  value: '{{workflow.parameters.appName}}'
+                - name: branch
+                  value: '{{workflow.parameters.branch}}'
+                - name: gitUrlNoProtocol
+                  value: '{{workflow.parameters.gitUrlNoProtocol}}'
+        - - name: pull-commit-empty-push
+            templateRef:
+              name: cwft-git
+              template: pull-commit-empty-push
+              clusterScope: true
+            arguments:
+              artifacts:
+                - name: repo-source
+                  from: '{{steps.checkout.outputs.artifacts.repo-source}}'
+              parameters:
+                - name: commitMessage
+                  value: 'chore: triggered an empty commit against main branch'
+                - name: gitUrlNoProtocol
+                  value: '{{workflow.parameters.gitUrlNoProtocol}}'
+                - name: repoName
+                  value: '{{workflow.parameters.appName}}'

--- a/.github/workflows/trigger.yaml
+++ b/.github/workflows/trigger.yaml
@@ -1,0 +1,44 @@
+name: trigger
+env:
+  ARGO_NAMESPACE: argo
+  ARGO_VERSION: v3.4.1
+
+on: workflow_dispatch
+
+jobs:
+  publish:
+    runs-on: self-hosted
+    steps:
+      - name: Setup Runner for Argo
+        run: |
+          cd $HOME
+          echo "Install argo"
+          # Download the binary
+          curl -sLO https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-amd64.gz
+          # Unzip
+          gunzip argo-linux-amd64.gz
+          # Make binary executable
+          chmod +x argo-linux-amd64
+          # Move binary to path
+          sudo mv ./argo-linux-amd64 /usr/local/bin/argo
+          # Test installation
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+      - run: echo ${GITHUB_REPOSITORY}
+      - run: echo ${GITHUB_REPOSITORY_NAME_PART}
+      - run: echo ${GITHUB_SERVER_URL}
+      - name: publish
+        run: |
+          echo "commit sha ${GITHUB_SHA}"
+          argo version --short
+          argo submit .argo/trigger.yaml \
+            --generate-name="${GITHUB_REPOSITORY_NAME_PART}-publish-${GITHUB_SHA_SHORT}-" \
+            -p appName="${GITHUB_REPOSITORY_NAME_PART}" \
+            -p branch="${GITHUB_REF_NAME}" \
+            -p containerRegistryURL="public.ecr.aws/kubefirst/${GITHUB_REPOSITORY_NAME_PART}:${GITHUB_SHA_SHORT}" \
+            -p gitUrlNoProtocol="git@github.com:${GITHUB_REPOSITORY_OWNER_PART_SLUG}" \
+            -p shortSha="${GITHUB_SHA_SHORT}" \
+            --wait --log
+      - run: echo "⭐️ the kubefirst open source platform is powered by github stars. give kubefirst one today https://github.com/kubefirst/kubefirst"


### PR DESCRIPTION
## Description
adds a github dispatch that can trigger an empty commit to trigger the creation of a new sha for deployment without the need to edit a file
