### PR TITLE
Fix minor inconsistencies with the API.

### DIFF
--- a/internal/router/api/v1/cluster.go
+++ b/internal/router/api/v1/cluster.go
@@ -289,7 +289,7 @@ func PostCreateCluster(c *gin.Context) {
 
 	// Retry mechanism
 	if cluster.ClusterName != "" {
-		//Assign cloud and git credentials
+		// Assign cloud and git credentials
 		clusterDefinition.AkamaiAuth = cluster.AkamaiAuth
 		clusterDefinition.AWSAuth = cluster.AWSAuth
 		clusterDefinition.CivoAuth = cluster.CivoAuth
@@ -602,7 +602,6 @@ func GetExportCluster(c *gin.Context) {
 }
 
 func GetClusterKubeConfig(c *gin.Context) {
-
 	cloudProvider, param := c.Params.Get("cloud_provider")
 	if !param {
 		c.JSON(http.StatusBadRequest, types.JSONFailureResponse{
@@ -627,13 +626,6 @@ func GetClusterKubeConfig(c *gin.Context) {
 
 	// Handle virtual cluster kubeconfig
 	if VCluster {
-		if err != nil {
-			c.JSON(http.StatusBadRequest, types.JSONFailureResponse{
-				Message: "error finding home directory",
-			})
-			return
-		}
-
 		if kubeConfigRequest.ManagClusterName == "" {
 			c.JSON(http.StatusBadRequest, types.JSONFailureResponse{
 				Message: "missing man_cluster_name",
@@ -743,7 +735,6 @@ func GetClusterKubeConfig(c *gin.Context) {
 		})
 		return
 	}
-	return
 }
 
 // PostImportCluster godoc

--- a/internal/router/api/v1/instanceSizes.go
+++ b/internal/router/api/v1/instanceSizes.go
@@ -91,11 +91,6 @@ func ListInstanceSizesForRegion(c *gin.Context) {
 			}
 		}
 
-		if err != nil {
-			fmt.Println("Error describing instance offerings:", err)
-			return
-		}
-
 		instanceSizes, err := awsConf.ListInstanceSizesForRegion()
 		if err != nil {
 			c.JSON(http.StatusBadRequest, types.JSONFailureResponse{
@@ -183,7 +178,6 @@ func ListInstanceSizesForRegion(c *gin.Context) {
 		}
 
 		instances, err := googleConf.ListInstances(instanceSizesRequest.CloudZone)
-
 		if err != nil {
 			c.JSON(http.StatusBadRequest, types.JSONFailureResponse{
 				Message: err.Error(),


### PR DESCRIPTION
## Description
We worked on this with @jarededwards but I don't think we ever had the chance to push it.

The log streamer has a few bugs as well as unnecessary complexity:

* The mutex is passed by copy, meaning the original never gets locked
* There are a few channels that, while there, are barely used
* There's a buffer that's unused, and it's also a string (a bit more expensive to manage than, say, a `bytes.Buffer`)
* The tailer tool's close function is never called, as such, none of the `inotify` signals are cleared on the system
* There is an unnecessary passing-around kind of function that could be heavily simplified

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
