### PR TITLE
upgrade akamai argo

### DIFF
--- a/internal/controller/argocd.go
+++ b/internal/controller/argocd.go
@@ -49,7 +49,7 @@ func (clctrl *ClusterController) InstallArgoCD() error {
 		var argoCDInstallPath string
 
 		switch clctrl.CloudProvider {
-		case "digitalocean", "aws", "civo", "google", "vultr":
+		case "digitalocean", "aws", "civo", "google", "vultr", "akamai":
 			argoCDInstallPath = "github.com:konstructio/manifests/argocd/cloud?ref=v1.1.0"
 		default:
 			argoCDInstallPath = fmt.Sprintf("github.com:kubefirst/manifests/argocd/cloud?ref=%s", pkg.KubefirstManifestRepoRef)


### PR DESCRIPTION
## Description
support argo v2.12,also refer the gitops-template [https://github.com/konstructio/gitops-template/compare/main...akamai-upgrade](url)

## How to test
build the kubefirst binary locally and have kubefirst-api running locally,and run "./kubefirst beta akamai --alerts-email <ALERTS_EMAIL> --github-org <GITHUB_ORG> --gitops-template-branch akamai-upgrade --domain-name <DOMAIN_NAME> --cluster-name <CLUSTER_NAME>"
