### PR TITLE
fix,feat: argo restart for k3d and argo upgrade

### DIFF
--- a/internal/argocd/auth.go
+++ b/internal/argocd/auth.go
@@ -93,6 +93,8 @@ func GetArgocdTokenV2(httpClient *http.Client, argocdBaseURL string, username st
 		return "", err
 	}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	res, err := httpClient.Do(req)
 	if err != nil {
 		return "", err

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -37,7 +37,7 @@ const (
 	MinioDefaultPassword         = "feedkraystars"
 
 	// github.com/kubefirst/manifests ref ver
-	KubefirstManifestRepoRef = "0.1.0"
+	KubefirstManifestRepoRef = "v1.1.0"
 )
 
 // Vault

--- a/internal/controller/argocd.go
+++ b/internal/controller/argocd.go
@@ -46,14 +46,7 @@ func (clctrl *ClusterController) InstallArgoCD() error {
 			}
 		}
 
-		var argoCDInstallPath string
-
-		switch clctrl.CloudProvider {
-		case "digitalocean", "aws", "civo", "google", "vultr", "akamai":
-			argoCDInstallPath = "github.com:konstructio/manifests/argocd/cloud?ref=v1.1.0"
-		default:
-			argoCDInstallPath = fmt.Sprintf("github.com:kubefirst/manifests/argocd/cloud?ref=%s", pkg.KubefirstManifestRepoRef)
-		}
+		argoCDInstallPath := fmt.Sprintf("github.com:konstructio/manifests/argocd/cloud?ref=%s", pkg.KubefirstManifestRepoRef)
 
 		log.Info().Msg("installing argocd")
 

--- a/pkg/k3d/k3d.go
+++ b/pkg/k3d/k3d.go
@@ -1,6 +1,9 @@
 package k3d
 
-import internal "github.com/konstructio/kubefirst-api/internal/k3d"
+import (
+	"github.com/konstructio/kubefirst-api/internal/controller"
+	internal "github.com/konstructio/kubefirst-api/internal/k3d"
+)
 
 const DomainName = internal.DomainName
 const GithubHost = internal.GithubHost
@@ -29,3 +32,4 @@ var DeleteK3dCluster = internal.DeleteK3dCluster
 var GenerateSingleTLSSecret = internal.GenerateSingleTLSSecret
 
 var ClusterCreateConsoleAPI = internal.ClusterCreateConsoleAPI
+var RestartDeployment = controller.RestartDeployment


### PR DESCRIPTION
## Description
add restart argocd for k3d and upgrade agro version 

## Related Issue(s)
timeout issues for vault in k3d

## How to test
we need to point in go mod file of kubefirst repo we need to add "replace github.com/konstructio/kubefirst-api v0.100.0 => "path-to-kubefirst-api-repository"" and run  ./kubefirst k3d create and also please refer (https://github.com/konstructio/kubefirst/compare/restart-argo?expand=1) this needs to be merged for the kubefirst part to get working
