### PR TITLE
Gitops repo commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+LABEL org.opencontainers.image.source=https://github.com/konstructio/kubefirst-api
+LABEL org.opencontainers.image.description="Kubefirst API that serves console frontend"
+LABEL org.opencontainers.image.licenses=MIT
+
 FROM golang:alpine AS builder
 
 ENV GO111MODULE=on \

--- a/pkg/providerConfigs/adjustDriver.go
+++ b/pkg/providerConfigs/adjustDriver.go
@@ -121,6 +121,9 @@ func AdjustGitopsRepo(
 		}
 	}
 
+	// clean git histroy
+	removeAllWithLogger(filepath.Join(gitopsRepoDir, ".git"))
+
 	if !useCloudflareOriginIssuer {
 		removeAllWithLogger(strings.ToLower(fmt.Sprintf("%s/%s-%s/templates/mgmt/cloudflare-origin-ca-issuer.yaml", gitopsRepoDir, cloudProvider, gitProvider)))
 		removeAllWithLogger(strings.ToLower(fmt.Sprintf("%s/%s-%s/templates/mgmt/cloudflare-origin-issuer-crd.yaml", gitopsRepoDir, cloudProvider, gitProvider)))
@@ -386,6 +389,12 @@ func PrepareGitRepositories(
 	}
 
 	// COMMIT
+	// * init gitops-template repo
+	gitopsRepo, err = git.PlainInit(gitopsDir, true)
+	if err != nil {
+		return fmt.Errorf("unable to initialize gitops repository at %s. %s", gitopsDir, err.Error())
+	}
+
 	// * commit initial gitops-template content
 	err = gitClient.Commit(gitopsRepo, "committing initial detokenized gitops-template repo content")
 	if err != nil {

--- a/pkg/providerConfigs/adjustDriver.go
+++ b/pkg/providerConfigs/adjustDriver.go
@@ -392,7 +392,7 @@ func PrepareGitRepositories(
 	// * init gitops-template repo
 	gitopsRepo, err := git.PlainInit(gitopsDir, false)
 	if err != nil {
-		return fmt.Errorf("unable to initialize gitops repository at %s. %s", gitopsDir, err.Error())
+		return fmt.Errorf("unable to initialize gitops repository at %s: %w", gitopsDir, err)
 	}
 
 	// * commit initial gitops-template content

--- a/pkg/providerConfigs/adjustDriver.go
+++ b/pkg/providerConfigs/adjustDriver.go
@@ -351,7 +351,7 @@ func PrepareGitRepositories(
 	useCloudflareOriginIssuer bool,
 ) error {
 	// * clone the gitops-template repo
-	gitopsRepo, err := gitClient.CloneRefSetMain(gitopsTemplateBranch, gitopsDir, gitopsTemplateURL)
+	_, err := gitClient.CloneRefSetMain(gitopsTemplateBranch, gitopsDir, gitopsTemplateURL)
 	if err != nil {
 		log.Error().Msgf("error opening repo at: %s, err: %s", gitopsDir, err.Error())
 		return fmt.Errorf("error opening repo at: %s, err: %w", gitopsDir, err)
@@ -390,7 +390,7 @@ func PrepareGitRepositories(
 
 	// COMMIT
 	// * init gitops-template repo
-	gitopsRepo, err = git.PlainInit(gitopsDir, true)
+	gitopsRepo, err := git.PlainInit(gitopsDir, false)
 	if err != nil {
 		return fmt.Errorf("unable to initialize gitops repository at %s. %s", gitopsDir, err.Error())
 	}


### PR DESCRIPTION
## Description
During a Kubefirst provision process the `gitops` repository, the one commit-ed to customer's account, contains all the commit histroy of `gitops-template`. Seeing ~1500 commits on a new created repository could be confusing for some users. This PR cleans the git history before pushing to `gitops` repository.

Additional this PR add's opencontainer label to the Dockerfile, so images created can be automatically visible under packages section in the repository . I believe the association has been manually created, but for consistency sake I am making the changes here.


## Related Issue(s)


## How to test

