### PR TITLE
fix:  (gitops-catalog) update to gh org to konstructio and specify branch

### DIFF
--- a/internal/gitShim/gitopsCatalog.go
+++ b/internal/gitShim/gitopsCatalog.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	KubefirstGitHubOrganization      = "kubefirst"
+	KubefirstGitHubOrganization      = "konstructio"
 	KubefirstGitopsCatalogRepository = "gitops-catalog"
 	basePath                         = "/"
+	branch                           = "main"
 )
 
 // GetGitopsCatalogRepo returns an object detailing the Kubefirst gitops catalog GitHub repository
@@ -39,12 +40,15 @@ func (gh *GitHubClient) GetGitopsCatalogRepo() (*github.Repository, error) {
 // ReadGitopsCatalogRepoContents reads the file and directory contents of the Kubefirst gitops catalog
 // GitHub repository
 func (gh *GitHubClient) ReadGitopsCatalogRepoContents() ([]*github.RepositoryContent, error) {
+	opts := &github.RepositoryContentGetOptions{
+		Ref: branch,
+	}
 	_, directoryContent, _, err := gh.Client.Repositories.GetContents(
 		context.Background(),
 		KubefirstGitHubOrganization,
 		KubefirstGitopsCatalogRepository,
 		basePath,
-		nil,
+		opts,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error getting gitops catalog repository contents: %w", err)


### PR DESCRIPTION
## Description
Updated organization from `kubefirst` to `konstructio` for GitopCatalog. Make main branch explicit.( should be noted in Gitops Catalog repo that branch can be changed.)

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
