### PR TITLE
fix vault new version for aws and gcp

### DIFF
--- a/internal/vault/autounseal.go
+++ b/internal/vault/autounseal.go
@@ -31,8 +31,6 @@ func (conf *Configuration) AutoUnseal() (*vaultapi.InitResponse, error) {
 	initResponse, err := vaultClient.Sys().Init(&vaultapi.InitRequest{
 		RecoveryShares:    RecoveryShares,
 		RecoveryThreshold: RecoveryThreshold,
-		SecretShares:      SecretShares,
-		SecretThreshold:   SecretThreshold,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing vault: %w", err)


### PR DESCRIPTION
## Description
in the new version of vault that is there on gitops template,we dont need the parameters SecretShares  ,SecretThreshold when initialising a client ,this was changed for other clouds in konstructio/manifests but for aws and gcp we use custom function which needs to be changed

## How to test
run the api locally and provision the cluster
/path/to/kubefirst civo create
--alerts-email
--github-org
--cluster-name
--domain-name