### PR TITLE
fix: change url of kubefirst console for k3d

### DIFF
--- a/pkg/reports/handoff.go
+++ b/pkg/reports/handoff.go
@@ -47,7 +47,7 @@ Note:
 
 --- Kubefirst Console
 ------------------------------------------------------------
-  URL: http://localhost:9094/services
+  URL: https://kubefirst.{{ .DomainName }}
 
 --- ArgoCD
 ------------------------------------------------------------


### PR DESCRIPTION
## Description
just a small msg fix for console link when we provision a k3d cluster
