### PR TITLE
fix:aws eks creation

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	runtime "github.com/konstructio/kubefirst-api/internal"
@@ -332,6 +333,10 @@ func (clctrl *ClusterController) InitController(def *types.ClusterDefinition) er
 	// Instantiate provider clients and copy cluster controller to cluster type
 	switch clctrl.CloudProvider {
 	case "aws":
+		os.Setenv("AWS_ACCESS_KEY_ID", clctrl.AWSAuth.AccessKeyID)
+		os.Setenv("AWS_SECRET_ACCESS_KEY", clctrl.AWSAuth.SecretAccessKey)
+		os.Setenv("AWS_SESSION_TOKEN", clctrl.AWSAuth.SessionToken)
+		os.Setenv("AWS_REGION", clctrl.CloudRegion)
 		conf, err := awsinternal.NewAwsV3(
 			clctrl.CloudRegion,
 			clctrl.AWSAuth.AccessKeyID,


### PR DESCRIPTION
## Description
aws sdk v2 is not taking the credentials.(accessKeyID, secretAccessKey, sessionToken ) to load the eks config,i tried to create session to pass into the "TokenOptions" but session is used only in v1 and api is using v2 of go sdk and they both are not compatible,the only good way to go is to set them as environment variables,this will not effect any provisioning of workload cluster as this is only used is k3d locally,

