### PR TITLE
fix: run terraform commands with -no-color flag

### DIFF
--- a/extensions/terraform/terraform.go
+++ b/extensions/terraform/terraform.go
@@ -23,13 +23,13 @@ func initActionAutoApprove(terraformClientPath string, tfAction, tfEntrypoint st
 		return fmt.Errorf("error: could not change to directory %s: %w", tfEntrypoint, err)
 	}
 
-	err = internal.ExecShellWithVars(tfEnvs, terraformClientPath, "init", "-force-copy")
+	err = internal.ExecShellWithVars(tfEnvs, terraformClientPath, "init", "-force-copy", "-no-color")
 	if err != nil {
 		log.Error().Msgf("error: terraform init for %s failed: %s", tfEntrypoint, err)
 		return fmt.Errorf("error: terraform init for %s failed: %w", tfEntrypoint, err)
 	}
 
-	err = internal.ExecShellWithVars(tfEnvs, terraformClientPath, tfAction, "-auto-approve")
+	err = internal.ExecShellWithVars(tfEnvs, terraformClientPath, tfAction, "-auto-approve", "-no-color")
 	if err != nil {
 		log.Error().Msgf("error: terraform %s -auto-approve for %s failed %s", tfAction, tfEntrypoint, err)
 		return fmt.Errorf("error: terraform %s -auto-approve for %s failed: %w", tfAction, tfEntrypoint, err)

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -25,13 +25,13 @@ func initActionAutoApprove(terraformClientPath, tfAction, tfEntrypoint string, t
 		log.Info().Msg("error: could not change to directory " + tfEntrypoint)
 		return fmt.Errorf("failed to change directory to %q: %w", tfEntrypoint, err)
 	}
-	err = pkg.ExecShellWithVars(tfEnvs, terraformClientPath, "init", "-force-copy")
+	err = pkg.ExecShellWithVars(tfEnvs, terraformClientPath, "init", "-force-copy", "-no-color")
 	if err != nil {
 		log.Printf("error: terraform init for %s failed: %s", tfEntrypoint, err)
 		return fmt.Errorf("terraform init for %q failed: %w", tfEntrypoint, err)
 	}
 
-	err = pkg.ExecShellWithVars(tfEnvs, terraformClientPath, tfAction, "-auto-approve", fmt.Sprintf("-parallelism=%d", runtime.NumCPU()*2))
+	err = pkg.ExecShellWithVars(tfEnvs, terraformClientPath, tfAction, "-auto-approve", fmt.Sprintf("-parallelism=%d", runtime.NumCPU()*2), "-no-color")
 	if err != nil {
 		log.Printf("error: terraform %s -auto-approve for %s failed %s", tfAction, tfEntrypoint, err)
 		return fmt.Errorf("terraform %s -auto-approve for %q failed: %w", tfAction, tfEntrypoint, err)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This makes the logs much nicer to read

### Before
![image](https://github.com/user-attachments/assets/adcdb889-738e-4932-9b61-901482302abe)

### After
![image](https://github.com/user-attachments/assets/0aa04484-8ffc-4f09-bb8d-2e70de54c7c5)

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #464 

## How to test
<!-- Provide steps to test this PR -->
Create a cluster using this API
