### PR TITLE
fix: initialise correct vault conf

### DIFF
--- a/pkg/credentials/root-credentials.go
+++ b/pkg/credentials/root-credentials.go
@@ -73,7 +73,7 @@ func ParseAuthData(clientset kubernetes.Interface, cloudProvider string, domainN
 				fmt.Println("Cannot retrieve Vault token automatically. Please provide one here:")
 				fmt.Scanln(&vaultRootToken)
 			}
-			vault := vault.Configuration{}
+			vault := vault.Conf
 			kbotPassword, err = vault.GetUserPassword(
 				vaultURL,
 				vaultRootToken,


### PR DESCRIPTION
## Description
initialise correct vault client

## Related Issue(s)

Fixes # https://github.com/konstructio/kubefirst/issues/2323

## How to test
provision Kubefirst in k3d environment,clone the Kubefirst and Kubefirst-api repo,in go.mod file of Kubefirst add the below line 
```bash 
     replace github.com/konstructio/kubefirst-api v0.115.0 => <PATH_TO_KUBEFIRST_API_REPO>
```
then run 
```bash 
     go build .
    ./kubefirst k3d root-credentials
```

