### PR TITLE
fix: use fullname for app.kubernetes.io/name label

### DIFF
--- a/charts/kubefirst-api/templates/_helpers.tpl
+++ b/charts/kubefirst-api/templates/_helpers.tpl
@@ -46,7 +46,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "kubefirst-api.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "kubefirst-api.name" . }}
+app.kubernetes.io/name: {{ include "kubefirst-api.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 


### PR DESCRIPTION
## Description
Use fullname template to set `app.kubernetes.io/name` label field. 

## Related Issue(s)
NA

## How to test
<!-- Provide steps to test this PR -->
