### PR TITLE
feat: detoknize `ORIGIN_ISSUER_IS_ENABLED` for metaphor

### DIFF
--- a/internal/controller/cluster.go
+++ b/internal/controller/cluster.go
@@ -285,6 +285,7 @@ func (clctrl *ClusterController) CreateTokens(kind string) interface{} {
 			MetaphorDevelopmentIngressURL: fmt.Sprintf("metaphor-development.%s", fullDomainName),
 			MetaphorStagingIngressURL:     fmt.Sprintf("metaphor-staging.%s", fullDomainName),
 			MetaphorProductionIngressURL:  fmt.Sprintf("metaphor-production.%s", fullDomainName),
+			OriginIssuerIsEnabled:         cl.CloudflareAuth.OriginCaIssuerKey != "",
 		}
 		return metaphorTemplateTokens
 	}

--- a/internal/router/api/v1/cluster.go
+++ b/internal/router/api/v1/cluster.go
@@ -327,6 +327,7 @@ func PostCreateCluster(c *gin.Context) {
 			clusterDefinition.GoogleAuth = cluster.GoogleAuth
 			clusterDefinition.K3sAuth = cluster.K3sAuth
 			clusterDefinition.GitAuth = cluster.GitAuth
+			clusterDefinition.CloudflareAuth = cluster.CloudflareAuth
 		}
 	}
 

--- a/pkg/providerConfigs/detokenize.go
+++ b/pkg/providerConfigs/detokenize.go
@@ -303,6 +303,7 @@ func detokenizeGitopsMetaphor(tokens *MetaphorTokenValues) filepath.WalkFunc {
 			newContents = strings.ReplaceAll(newContents, "<METAPHOR_DEVELOPMENT_INGRESS_URL>", tokens.MetaphorDevelopmentIngressURL)
 			newContents = strings.ReplaceAll(newContents, "<METAPHOR_PRODUCTION_INGRESS_URL>", tokens.MetaphorProductionIngressURL)
 			newContents = strings.ReplaceAll(newContents, "<METAPHOR_STAGING_INGRESS_URL>", tokens.MetaphorStagingIngressURL)
+			newContents = strings.ReplaceAll(newContents, "<ORIGIN_ISSUER_IS_ENABLED>", fmt.Sprintf("%t", tokens.OriginIssuerIsEnabled))
 
 			err = os.WriteFile(path, []byte(newContents), 0)
 			if err != nil {

--- a/pkg/providerConfigs/types.go
+++ b/pkg/providerConfigs/types.go
@@ -109,4 +109,5 @@ type MetaphorTokenValues struct {
 	MetaphorDevelopmentIngressURL string
 	MetaphorProductionIngressURL  string
 	MetaphorStagingIngressURL     string
+	OriginIssuerIsEnabled         bool
 }


### PR DESCRIPTION
## Description
Detoknize `ORIGIN_ISSUER_IS_ENABLED` field to enable Metaphor to use Cloudflare's origin issuer.

## Related Issue(s)
KRA-75

## How to test
Build or run kubefirst from this branch and set the following env variables before creating a managment cluster
```
K1_LOCAL_KUBECONFIG_PATH=
K1_CONSOLE_REMOTE_URL=
K1_ACCESS_TOKEN=
K1_LOCAL_DEBUG=
CIVO_TOKEN=
GITHUB_TOKEN=
CF_ORIGIN_CA_ISSUER_API_TOKEN=
CF_API_TOKEN=
SUBDOMAIN=
```

User `KRA-75` as your `gitops-template-branch`
```
go run .  civo create --alerts-email general-io@konstr
uct.io --github-org k1-civo --subdomain <cluster-name> --domain-name<domain> --cluster-name <cluster-name>  --dns-provider cloudflare 
--cloud-region fra1 --gitops-template-url https://github.com/konstructio/gitops-template --gitops-template-branch KRA-75
```