### PR TITLE
Make AMIType validation only required for AWS

### DIFF
--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -37,7 +37,7 @@ type ClusterDefinition struct {
 
 	// AWS
 	ECR     bool   `json:"ecr,omitempty"`
-	AMIType string `json:"ami_type" binding:"required"`
+	AMIType string `json:"ami_type" binding:"required_if=CloudProvider aws"`
 
 	// Azure
 	AzureDNSZoneResourceGroup string `json:"azure_dns_zone_resource_group,omitempty"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When building a non-AWS instance, the validation was failing with the message:

```json
{"error":"Key: 'ClusterDefinition.AMIType' Error:Field validation for 'AMIType' failed on the 'required_if' tag"}
```

This is due to the `ClusterDefinition.AMIType` having `required` validation, despite being AWS-specific (introduced in #528). This changes the validation to [required_if](https://pkg.go.dev/github.com/go-playground/validator/v10#hdr-Required_If) and only activated for AWS.

~Also bundled in an update to the Swagger docs as was outdated (it's a pre-commit hook, so please install that in your dev environments all)~

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Install Azure/GCP without the `AMIType` set - should pass
- Install AWS without the `AMIType` set - should fail validation
- Install AWS with the `AMIType` set - should pass