### PR TITLE
fix: add instancetracker if nill

### DIFF
--- a/internal/progressPrinter/progress.go
+++ b/internal/progressPrinter/progress.go
@@ -102,6 +102,9 @@ func CreateTracker(title string, total int64) *progress.Tracker {
 		Units:   progress.UnitsDefault,
 	}
 
+	if instance == nil {
+		instance = GetInstance()
+	}
 	instance.pw.AppendTracker(tracker)
 	return tracker
 }


### PR DESCRIPTION
## Description
initialise the tracker if nill 

## How to test
in Kubefirst go.mod add `replace github.com/konstructio/kubefirst-api v0.122.0 => <PATH_TO _KUBEFIRST_API_WITH_fix-k3d-branch>` and run `go run . k3d create`

