### PR TITLE
Fix steps

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1190,6 +1190,9 @@ const docTemplate = `{
                     "description": "Container Registry and Secrets",
                     "type": "boolean"
                 },
+                "final_check": {
+                    "type": "boolean"
+                },
                 "git_auth": {
                     "$ref": "#/definitions/types.GitAuth"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1184,6 +1184,9 @@
                     "description": "Container Registry and Secrets",
                     "type": "boolean"
                 },
+                "final_check": {
+                    "type": "boolean"
+                },
                 "git_auth": {
                     "$ref": "#/definitions/types.GitAuth"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -133,6 +133,8 @@ definitions:
       ecr:
         description: Container Registry and Secrets
         type: boolean
+      final_check:
+        type: boolean
       git_auth:
         $ref: '#/definitions/types.GitAuth'
       git_host:

--- a/internal/controller/final_check.go
+++ b/internal/controller/final_check.go
@@ -1,0 +1,106 @@
+package controller
+
+import (
+	"fmt"
+
+	"github.com/konstructio/kubefirst-api/internal/constants"
+	"github.com/konstructio/kubefirst-api/internal/k8s"
+	"github.com/konstructio/kubefirst-api/internal/secrets"
+	"github.com/konstructio/kubefirst-api/internal/services"
+	log "github.com/rs/zerolog/log"
+)
+
+func (clctrl *ClusterController) FinalCheck() error {
+	// Wait for last sync wave app transition to Running
+	log.Info().Msg("waiting for final sync wave Deployment to transition to Running")
+	crossplaneDeployment, err := k8s.ReturnDeploymentObject(
+		clctrl.Kcfg.Clientset,
+		"app.kubernetes.io/instance",
+		"crossplane",
+		"crossplane-system",
+		3600,
+	)
+	if err != nil {
+		clctrl.UpdateClusterOnError(err.Error())
+		return fmt.Errorf("error finding crossplane Deployment: %w", err)
+	}
+
+	log.Info().Msg("waiting on dns, tls certificates from letsencrypt and remaining sync waves.\n this may take up to 60 minutes but regularly completes in under 20 minutes")
+	_, err = k8s.WaitForDeploymentReady(clctrl.Kcfg.Clientset, crossplaneDeployment, 3600)
+	if err != nil {
+		clctrl.UpdateClusterOnError(err.Error())
+		return fmt.Errorf("error waiting for crossplane deployment to enter Ready state: %w", err)
+	}
+
+	// * export and import cluster
+	if err := clctrl.ExportClusterRecord(); err != nil {
+		log.Error().Msgf("Error exporting cluster record: %s", err)
+		return fmt.Errorf("error exporting cluster record: %w", err)
+	}
+	clctrl.Cluster.Status = constants.ClusterStatusProvisioned
+	clctrl.Cluster.InProgress = false
+
+	if err := secrets.UpdateCluster(clctrl.KubernetesClient, clctrl.Cluster); err != nil {
+		return fmt.Errorf("error updating cluster status: %w", err)
+	}
+
+	log.Info().Msg("cluster creation complete")
+
+	// Create default service entries
+	cl, err := secrets.GetCluster(clctrl.KubernetesClient, clctrl.ClusterName)
+	if err != nil {
+		log.Error().Msgf("error getting cluster %s: %s", clctrl.ClusterName, err)
+		clctrl.UpdateClusterOnError(err.Error())
+		return fmt.Errorf("error getting cluster %s: %w", clctrl.ClusterName, err)
+	}
+
+	if err := services.AddDefaultServices(cl); err != nil {
+		log.Error().Msgf("error adding default service entries for cluster %s: %s", cl.ClusterName, err)
+		clctrl.UpdateClusterOnError(err.Error())
+		return fmt.Errorf("error adding default service entries for cluster %s: %w", cl.ClusterName, err)
+	}
+
+	if clctrl.InstallKubefirstPro {
+		log.Info().Msg("waiting for kubefirst-pro-api Deployment to transition to Running")
+		kubefirstProAPI, err := k8s.ReturnDeploymentObject(
+			clctrl.Kcfg.Clientset,
+			"app.kubernetes.io/name",
+			"kubefirst-pro-api",
+			"kubefirst",
+			1200,
+		)
+		if err != nil {
+			clctrl.UpdateClusterOnError(err.Error())
+			return fmt.Errorf("error finding kubefirst-pro-api Deployment: %w", err)
+		}
+
+		_, err = k8s.WaitForDeploymentReady(clctrl.Kcfg.Clientset, kubefirstProAPI, 300)
+		if err != nil {
+			clctrl.UpdateClusterOnError(err.Error())
+			return fmt.Errorf("error waiting for kubefirst-pro-api deployment to enter Ready state: %w", err)
+		}
+	}
+
+	// Wait for last sync wave app transition to Running
+	log.Info().Msg("waiting for final sync wave Deployment to transition to Running")
+	argocdDeployment, err := k8s.ReturnDeploymentObject(
+		clctrl.Kcfg.Clientset,
+		"app.kubernetes.io/name",
+		"argocd-server",
+		"argocd",
+		3600,
+	)
+	if err != nil {
+		clctrl.UpdateClusterOnError(err.Error())
+		return fmt.Errorf("error finding argocd Deployment: %w", err)
+	}
+	_, err = k8s.WaitForDeploymentReady(clctrl.Kcfg.Clientset, argocdDeployment, 3600)
+	if err != nil {
+		clctrl.UpdateClusterOnError(err.Error())
+		return fmt.Errorf("error waiting for argocd deployment to enter Ready state: %w", err)
+	}
+
+	clctrl.Cluster.FinalCheck = true
+	log.Info().Msg("cluster creation complete")
+	return nil
+}

--- a/internal/k3d/adjustContent.go
+++ b/internal/k3d/adjustContent.go
@@ -21,7 +21,6 @@ import (
 )
 
 func AdjustGitopsRepo(cloudProvider, clusterName, clusterType, gitopsRepoDir, gitProvider string, removeAtlantis, installKubefirstPro bool) error {
-
 	// * clean up all other platforms
 	for _, platform := range pkg.SupportedPlatforms {
 		if platform != fmt.Sprintf("%s-%s", CloudProvider, gitProvider) {

--- a/internal/k3d/adjustContent.go
+++ b/internal/k3d/adjustContent.go
@@ -21,6 +21,9 @@ import (
 )
 
 func AdjustGitopsRepo(cloudProvider, clusterName, clusterType, gitopsRepoDir, gitProvider string, removeAtlantis, installKubefirstPro bool) error {
+	log.Info().Msgf("gitops  directorty is %s", gitopsRepoDir)
+	log.Info().Msgf("cluster type is %s", clusterType)
+
 	// * clean up all other platforms
 	for _, platform := range pkg.SupportedPlatforms {
 		if platform != fmt.Sprintf("%s-%s", CloudProvider, gitProvider) {
@@ -70,6 +73,8 @@ func AdjustGitopsRepo(cloudProvider, clusterName, clusterType, gitopsRepoDir, gi
 	if err := os.RemoveAll(fmt.Sprintf("%s/services", gitopsRepoDir)); err != nil {
 		log.Error().Msgf("Error removing %q: %s", fmt.Sprintf("%s/services", gitopsRepoDir), err.Error())
 	}
+
+	return nil
 
 	registryLocation := fmt.Sprintf("%s/registry/%s", gitopsRepoDir, clusterName)
 	if pkg.LocalhostARCH == "arm64" && cloudProvider == CloudProvider {

--- a/internal/k3d/adjustContent.go
+++ b/internal/k3d/adjustContent.go
@@ -21,8 +21,6 @@ import (
 )
 
 func AdjustGitopsRepo(cloudProvider, clusterName, clusterType, gitopsRepoDir, gitProvider string, removeAtlantis, installKubefirstPro bool) error {
-	log.Info().Msgf("gitops  directorty is %s", gitopsRepoDir)
-	log.Info().Msgf("cluster type is %s", clusterType)
 
 	// * clean up all other platforms
 	for _, platform := range pkg.SupportedPlatforms {
@@ -73,8 +71,6 @@ func AdjustGitopsRepo(cloudProvider, clusterName, clusterType, gitopsRepoDir, gi
 	if err := os.RemoveAll(fmt.Sprintf("%s/services", gitopsRepoDir)); err != nil {
 		log.Error().Msgf("Error removing %q: %s", fmt.Sprintf("%s/services", gitopsRepoDir), err.Error())
 	}
-
-	return nil
 
 	registryLocation := fmt.Sprintf("%s/registry/%s", gitopsRepoDir, clusterName)
 	if pkg.LocalhostARCH == "arm64" && cloudProvider == CloudProvider {

--- a/pkg/types/cluster.go
+++ b/pkg/types/cluster.go
@@ -148,6 +148,7 @@ type Cluster struct {
 	VaultInitializedCheck          bool              `bson:"vault_initialized_check" json:"vault_initialized_check"`
 	VaultTerraformApplyCheck       bool              `bson:"vault_terraform_apply_check" json:"vault_terraform_apply_check"`
 	UsersTerraformApplyCheck       bool              `bson:"users_terraform_apply_check" json:"users_terraform_apply_check"`
+	FinalCheck                     bool              `bson:"final_check" json:"final_check"`
 	WorkloadClusters               []WorkloadCluster `bson:"workload_clusters,omitempty" json:"workload_clusters,omitempty"`
 }
 

--- a/providers/aws/create.go
+++ b/providers/aws/create.go
@@ -11,11 +11,9 @@ import (
 
 	awsext "github.com/konstructio/kubefirst-api/extensions/aws"
 	awsinternal "github.com/konstructio/kubefirst-api/internal/aws"
-	"github.com/konstructio/kubefirst-api/internal/constants"
 	"github.com/konstructio/kubefirst-api/internal/controller"
 	"github.com/konstructio/kubefirst-api/internal/k8s"
 	"github.com/konstructio/kubefirst-api/internal/secrets"
-	"github.com/konstructio/kubefirst-api/internal/services"
 	pkgtypes "github.com/konstructio/kubefirst-api/pkg/types"
 	log "github.com/rs/zerolog/log"
 )
@@ -201,95 +199,11 @@ func CreateAWSCluster(definition *pkgtypes.ClusterDefinition) error {
 		return fmt.Errorf("error running users terraform: %w", err)
 	}
 
-	// Wait for last sync wave app transition to Running
-	log.Info().Msg("waiting for final sync wave Deployment to transition to Running")
-	crossplaneDeployment, err := k8s.ReturnDeploymentObject(
-		ctrl.Kcfg.Clientset,
-		"app.kubernetes.io/instance",
-		"crossplane",
-		"crossplane-system",
-		3600,
-	)
-	if err != nil {
+	if err := ctrl.FinalCheck(); err != nil {
+		log.Error().Msgf("error doing final check: %s", err)
 		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error finding crossplane Deployment: %w", err)
+		return fmt.Errorf("error doing final check: %w", err)
 	}
 
-	log.Info().Msg("waiting on dns, tls certificates from letsencrypt and remaining sync waves.\n this may take up to 60 minutes but regularly completes in under 20 minutes")
-	_, err = k8s.WaitForDeploymentReady(ctrl.Kcfg.Clientset, crossplaneDeployment, 3600)
-	if err != nil {
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error waiting for crossplane deployment to enter Ready state: %w", err)
-	}
-
-	// * export and import cluster
-	if err := ctrl.ExportClusterRecord(); err != nil {
-		log.Error().Msgf("Error exporting cluster record: %s", err)
-		return fmt.Errorf("error exporting cluster record: %w", err)
-	}
-	ctrl.Cluster.Status = constants.ClusterStatusProvisioned
-	ctrl.Cluster.InProgress = false
-
-	if err := secrets.UpdateCluster(ctrl.KubernetesClient, ctrl.Cluster); err != nil {
-		return fmt.Errorf("error updating cluster status: %w", err)
-	}
-
-	log.Info().Msg("cluster creation complete")
-
-	// Create default service entries
-	cl, err := secrets.GetCluster(ctrl.KubernetesClient, ctrl.ClusterName)
-	if err != nil {
-		log.Error().Msgf("error getting cluster %s: %s", ctrl.ClusterName, err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error getting cluster %s: %w", ctrl.ClusterName, err)
-	}
-
-	if err := services.AddDefaultServices(cl); err != nil {
-		log.Error().Msgf("error adding default service entries for cluster %s: %s", cl.ClusterName, err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error adding default service entries for cluster %s: %w", cl.ClusterName, err)
-	}
-
-	if ctrl.InstallKubefirstPro {
-		log.Info().Msg("waiting for kubefirst-pro-api Deployment to transition to Running")
-		kubefirstProAPI, err := k8s.ReturnDeploymentObject(
-			ctrl.Kcfg.Clientset,
-			"app.kubernetes.io/name",
-			"kubefirst-pro-api",
-			"kubefirst",
-			1200,
-		)
-		if err != nil {
-			ctrl.UpdateClusterOnError(err.Error())
-			return fmt.Errorf("error finding kubefirst-pro-api Deployment: %w", err)
-		}
-
-		_, err = k8s.WaitForDeploymentReady(ctrl.Kcfg.Clientset, kubefirstProAPI, 300)
-		if err != nil {
-			ctrl.UpdateClusterOnError(err.Error())
-			return fmt.Errorf("error waiting for kubefirst-pro-api deployment to enter Ready state: %w", err)
-		}
-	}
-
-	// Wait for last sync wave app transition to Running
-	log.Info().Msg("waiting for final sync wave Deployment to transition to Running")
-	argocdDeployment, err := k8s.ReturnDeploymentObject(
-		ctrl.Kcfg.Clientset,
-		"app.kubernetes.io/name",
-		"argocd-server",
-		"argocd",
-		3600,
-	)
-	if err != nil {
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error finding argocd Deployment: %w", err)
-	}
-	_, err = k8s.WaitForDeploymentReady(ctrl.Kcfg.Clientset, argocdDeployment, 3600)
-	if err != nil {
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error waiting for argocd deployment to enter Ready state: %w", err)
-	}
-
-	log.Info().Msg("cluster creation complete")
 	return nil
 }

--- a/providers/civo/create.go
+++ b/providers/civo/create.go
@@ -10,11 +10,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/konstructio/kubefirst-api/internal/constants"
 	"github.com/konstructio/kubefirst-api/internal/controller"
 	"github.com/konstructio/kubefirst-api/internal/k8s"
 	"github.com/konstructio/kubefirst-api/internal/secrets"
-	"github.com/konstructio/kubefirst-api/internal/services"
 	"github.com/konstructio/kubefirst-api/internal/ssl"
 	pkgtypes "github.com/konstructio/kubefirst-api/pkg/types"
 	log "github.com/rs/zerolog/log"
@@ -196,103 +194,11 @@ func CreateCivoCluster(definition *pkgtypes.ClusterDefinition) error {
 		return fmt.Errorf("error running users terraform: %w", err)
 	}
 
-	// Wait for last sync wave app transition to Running
-	log.Info().Msg("waiting for final sync wave Deployment to transition to Running")
-	crossplaneDeployment, err := k8s.ReturnDeploymentObject(
-		kcfg.Clientset,
-		"app.kubernetes.io/instance",
-		"crossplane",
-		"crossplane-system",
-		3600,
-	)
-	if err != nil {
-		log.Error().Msgf("Error finding crossplane Deployment: %s", err)
+	if err := ctrl.FinalCheck(); err != nil {
+		log.Error().Msgf("error doing final check: %s", err)
 		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error finding crossplane Deployment: %w", err)
+		return fmt.Errorf("error doing final check: %w", err)
 	}
-	log.Info().Msg("waiting on dns, tls certificates from letsencrypt and remaining sync waves.\n this may take up to 60 minutes but regularly completes in under 20 minutes")
-	_, err = k8s.WaitForDeploymentReady(kcfg.Clientset, crossplaneDeployment, 3600)
-	if err != nil {
-		log.Error().Msgf("Error waiting for all Apps to sync ready state: %s", err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error waiting for all Apps to sync ready state: %w", err)
-	}
-
-	// * export and import cluster
-	err = ctrl.ExportClusterRecord()
-	if err != nil {
-		log.Error().Msgf("Error exporting cluster record: %s", err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error exporting cluster record: %w", err)
-	}
-	// Create default service entries
-	cl, err := secrets.GetCluster(ctrl.KubernetesClient, ctrl.ClusterName)
-	if err != nil {
-		log.Error().Msgf("error getting cluster %s: %s", ctrl.ClusterName, err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error getting cluster %s: %w", ctrl.ClusterName, err)
-	}
-
-	err = services.AddDefaultServices(cl)
-	if err != nil {
-		log.Error().Msgf("error adding default service entries for cluster %s: %s", cl.ClusterName, err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error adding default service entries for cluster %s: %w", cl.ClusterName, err)
-	}
-
-	if ctrl.InstallKubefirstPro {
-		log.Info().Msg("waiting for kubefirst-pro-api Deployment to transition to Running")
-		kubefirstProAPI, err := k8s.ReturnDeploymentObject(
-			kcfg.Clientset,
-			"app.kubernetes.io/name",
-			"kubefirst-pro-api",
-			"kubefirst",
-			1200,
-		)
-		if err != nil {
-			log.Error().Msgf("Error finding kubefirst-pro-api Deployment: %s", err)
-			ctrl.UpdateClusterOnError(err.Error())
-			return fmt.Errorf("error finding kubefirst-pro-api Deployment: %w", err)
-		}
-
-		_, err = k8s.WaitForDeploymentReady(kcfg.Clientset, kubefirstProAPI, 300)
-		if err != nil {
-			log.Error().Msgf("Error waiting for kubefirst-pro-api to transition to Running: %s", err)
-			ctrl.UpdateClusterOnError(err.Error())
-			return fmt.Errorf("error waiting for kubefirst-pro-api to transition to Running: %w", err)
-		}
-	}
-
-	// Wait for last sync wave app transition to Running
-	log.Info().Msg("waiting for final sync wave Deployment to transition to Running")
-	argocdDeployment, err := k8s.ReturnDeploymentObject(
-		kcfg.Clientset,
-		"app.kubernetes.io/name",
-		"argocd-server",
-		"argocd",
-		3600,
-	)
-	if err != nil {
-		log.Error().Msgf("Error finding argocd Deployment: %s", err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error finding argocd Deployment: %w", err)
-	}
-	_, err = k8s.WaitForDeploymentReady(kcfg.Clientset, argocdDeployment, 3600)
-	if err != nil {
-		log.Error().Msgf("Error waiting for argocd deployment to enter Ready state: %s", err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error waiting for argocd deployment to enter Ready state: %w", err)
-	}
-
-	ctrl.Cluster.Status = constants.ClusterStatusProvisioned
-	ctrl.Cluster.InProgress = false
-	err = secrets.UpdateCluster(ctrl.KubernetesClient, ctrl.Cluster)
-	if err != nil {
-		log.Error().Msgf("error updating cluster status: %s", err)
-		return fmt.Errorf("error updating cluster status: %w", err)
-	}
-
-	log.Info().Msg("cluster creation complete")
 
 	return nil
 }

--- a/providers/digitalocean/create.go
+++ b/providers/digitalocean/create.go
@@ -10,11 +10,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/konstructio/kubefirst-api/internal/constants"
 	"github.com/konstructio/kubefirst-api/internal/controller"
 	"github.com/konstructio/kubefirst-api/internal/k8s"
 	"github.com/konstructio/kubefirst-api/internal/secrets"
-	"github.com/konstructio/kubefirst-api/internal/services"
 	"github.com/konstructio/kubefirst-api/internal/ssl"
 	pkgtypes "github.com/konstructio/kubefirst-api/pkg/types"
 	log "github.com/rs/zerolog/log"
@@ -195,97 +193,11 @@ func CreateDigitaloceanCluster(definition *pkgtypes.ClusterDefinition) error {
 		return fmt.Errorf("error running users terraform: %w", err)
 	}
 
-	// Wait for last sync wave app transition to Running
-	log.Info().Msg("waiting for final sync wave Deployment to transition to Running")
-	crossplaneDeployment, err := k8s.ReturnDeploymentObject(
-		kcfg.Clientset,
-		"app.kubernetes.io/instance",
-		"crossplane",
-		"crossplane-system",
-		3600,
-	)
-	if err != nil {
-		log.Error().Msgf("Error finding crossplane Deployment: %s", err)
+	if err := ctrl.FinalCheck(); err != nil {
+		log.Error().Msgf("error doing final check: %s", err)
 		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error finding crossplane Deployment: %w", err)
+		return fmt.Errorf("error doing final check: %w", err)
 	}
-	log.Info().Msg("waiting on dns, tls certificates from letsencrypt and remaining sync waves.\n this may take up to 60 minutes but regularly completes in under 20 minutes")
-	_, err = k8s.WaitForDeploymentReady(kcfg.Clientset, crossplaneDeployment, 3600)
-	if err != nil {
-		log.Error().Msgf("Error waiting for all Apps to sync ready state: %s", err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error waiting for all Apps to sync ready state: %w", err)
-	}
-
-	// export and import cluster
-	err = ctrl.ExportClusterRecord()
-	if err != nil {
-		log.Error().Msgf("Error exporting cluster record: %s", err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error exporting cluster record: %w", err)
-	}
-
-	// Create default service entries
-	cl, _ := secrets.GetCluster(ctrl.KubernetesClient, ctrl.ClusterName)
-	err = services.AddDefaultServices(cl)
-	if err != nil {
-		log.Error().Msgf("error adding default service entries for cluster %s: %s", cl.ClusterName, err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error adding default service entries for cluster %s: %w", cl.ClusterName, err)
-	}
-
-	if ctrl.InstallKubefirstPro {
-		log.Info().Msg("waiting for kubefirst-pro-api Deployment to transition to Running")
-		kubefirstProAPI, err := k8s.ReturnDeploymentObject(
-			kcfg.Clientset,
-			"app.kubernetes.io/name",
-			"kubefirst-pro-api",
-			"kubefirst",
-			1200,
-		)
-		if err != nil {
-			log.Error().Msgf("Error finding kubefirst-pro-api Deployment: %s", err)
-			ctrl.UpdateClusterOnError(err.Error())
-			return fmt.Errorf("error finding kubefirst-pro-api Deployment: %w", err)
-		}
-
-		_, err = k8s.WaitForDeploymentReady(kcfg.Clientset, kubefirstProAPI, 300)
-		if err != nil {
-			log.Error().Msgf("Error waiting for kubefirst-pro-api to transition to Running: %s", err)
-			ctrl.UpdateClusterOnError(err.Error())
-			return fmt.Errorf("error waiting for kubefirst-pro-api to transition to Running: %w", err)
-		}
-	}
-
-	// Wait for last sync wave app transition to Running
-	log.Info().Msg("waiting for final sync wave Deployment to transition to Running")
-	argocdDeployment, err := k8s.ReturnDeploymentObject(
-		kcfg.Clientset,
-		"app.kubernetes.io/name",
-		"argocd-server",
-		"argocd",
-		3600,
-	)
-	if err != nil {
-		log.Error().Msgf("Error finding argocd Deployment: %s", err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error finding argocd Deployment: %w", err)
-	}
-	_, err = k8s.WaitForDeploymentReady(kcfg.Clientset, argocdDeployment, 3600)
-	if err != nil {
-		log.Error().Msgf("Error waiting for argocd deployment to enter Ready state: %s", err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error waiting for argocd deployment to enter Ready state: %w", err)
-	}
-
-	ctrl.Cluster.Status = constants.ClusterStatusProvisioned
-	ctrl.Cluster.InProgress = false
-	err = secrets.UpdateCluster(ctrl.KubernetesClient, ctrl.Cluster)
-	if err != nil {
-		return fmt.Errorf("error updating cluster status after provisioning: %w", err)
-	}
-
-	log.Info().Msg("cluster creation complete")
 
 	return nil
 }

--- a/providers/k3s/create.go
+++ b/providers/k3s/create.go
@@ -10,11 +10,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/konstructio/kubefirst-api/internal/constants"
 	"github.com/konstructio/kubefirst-api/internal/controller"
 	"github.com/konstructio/kubefirst-api/internal/k8s"
 	"github.com/konstructio/kubefirst-api/internal/secrets"
-	"github.com/konstructio/kubefirst-api/internal/services"
 	"github.com/konstructio/kubefirst-api/internal/ssl"
 	pkgtypes "github.com/konstructio/kubefirst-api/pkg/types"
 	log "github.com/rs/zerolog/log"
@@ -195,99 +193,11 @@ func CreateK3sCluster(definition *pkgtypes.ClusterDefinition) error {
 		return fmt.Errorf("error running users terraform: %w", err)
 	}
 
-	// Wait for last sync wave app transition to Running
-	log.Info().Msg("waiting for final sync wave Deployment to transition to Running")
-	crossplaneDeployment, err := k8s.ReturnDeploymentObject(
-		kcfg.Clientset,
-		"app.kubernetes.io/instance",
-		"crossplane",
-		"crossplane-system",
-		3600,
-	)
-	if err != nil {
-		log.Error().Msgf("Error finding crossplane Deployment: %s", err)
+	if err := ctrl.FinalCheck(); err != nil {
+		log.Error().Msgf("error doing final check: %s", err)
 		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error finding crossplane Deployment: %w", err)
+		return fmt.Errorf("error doing final check: %w", err)
 	}
-	log.Info().Msgf("waiting on dns, tls certificates from letsencrypt and remaining sync waves.\n this may take up to 60 minutes but regularly completes in under 20 minutes")
-	_, err = k8s.WaitForDeploymentReady(kcfg.Clientset, crossplaneDeployment, 3600)
-	if err != nil {
-		log.Error().Msgf("Error waiting for all Apps to sync ready state: %s", err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error waiting for all Apps to sync ready state: %w", err)
-	}
-
-	// * export and import cluster
-	err = ctrl.ExportClusterRecord()
-	if err != nil {
-		log.Error().Msgf("Error exporting cluster record: %s", err)
-		return fmt.Errorf("error exporting cluster record: %w", err)
-	}
-
-	ctrl.Cluster.InProgress = false
-	ctrl.Cluster.Status = constants.ClusterStatusProvisioned
-	err = secrets.UpdateCluster(ctrl.KubernetesClient, ctrl.Cluster)
-	if err != nil {
-		return fmt.Errorf("error updating cluster secrets: %w", err)
-	}
-
-	log.Info().Msg("cluster creation complete")
-
-	// Create default service entries
-	cl, _ := secrets.GetCluster(ctrl.KubernetesClient, ctrl.ClusterName)
-	err = services.AddDefaultServices(cl)
-	if err != nil {
-		log.Error().Msgf("error adding default service entries for cluster %s: %s", cl.ClusterName, err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error adding default service entries for cluster %s: %w", cl.ClusterName, err)
-	}
-
-	if ctrl.InstallKubefirstPro {
-		log.Info().Msg("waiting for kubefirst-pro-api Deployment to transition to Running")
-		kubefirstProAPI, err := k8s.ReturnDeploymentObject(
-			kcfg.Clientset,
-			"app.kubernetes.io/name",
-			"kubefirst-pro-api",
-			"kubefirst",
-			1200,
-		)
-		if err != nil {
-			log.Error().Msgf("Error finding kubefirst-pro-api Deployment: %s", err)
-			ctrl.UpdateClusterOnError(err.Error())
-			return fmt.Errorf("error finding kubefirst-pro-api Deployment: %w", err)
-		}
-
-		_, err = k8s.WaitForDeploymentReady(kcfg.Clientset, kubefirstProAPI, 300)
-		if err != nil {
-			log.Error().Msgf("Error waiting for kubefirst-pro-api to transition to Running: %s", err)
-			ctrl.UpdateClusterOnError(err.Error())
-			return fmt.Errorf("error waiting for kubefirst-pro-api to transition to Running: %w", err)
-		}
-	}
-
-	// Wait for last sync wave app transition to Running
-	log.Info().Msg("waiting for final sync wave Deployment to transition to Running")
-	argocdDeployment, err := k8s.ReturnDeploymentObject(
-		kcfg.Clientset,
-		"app.kubernetes.io/name",
-		"argocd-server",
-		"argocd",
-		3600,
-	)
-	if err != nil {
-		log.Error().Msgf("Error finding argocd Deployment: %s", err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error finding argocd Deployment: %w", err)
-	}
-	_, err = k8s.WaitForDeploymentReady(kcfg.Clientset, argocdDeployment, 3600)
-	if err != nil {
-		log.Error().Msgf("Error waiting for argocd deployment to enter Ready state: %s", err)
-
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error waiting for argocd deployment to enter Ready state: %w", err)
-	}
-
-	log.Info().Msg("cluster creation complete")
 
 	return nil
 }

--- a/providers/vultr/create.go
+++ b/providers/vultr/create.go
@@ -10,11 +10,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/konstructio/kubefirst-api/internal/constants"
 	"github.com/konstructio/kubefirst-api/internal/controller"
 	"github.com/konstructio/kubefirst-api/internal/k8s"
 	"github.com/konstructio/kubefirst-api/internal/secrets"
-	"github.com/konstructio/kubefirst-api/internal/services"
 	"github.com/konstructio/kubefirst-api/internal/ssl"
 	pkgtypes "github.com/konstructio/kubefirst-api/pkg/types"
 	log "github.com/rs/zerolog/log"
@@ -194,100 +192,11 @@ func CreateVultrCluster(definition *pkgtypes.ClusterDefinition) error {
 		return fmt.Errorf("failed to run users terraform: %w", err)
 	}
 
-	// Wait for last sync wave app transition to Running
-	log.Info().Msg("waiting for final sync wave Deployment to transition to Running")
-	crossplaneDeployment, err := k8s.ReturnDeploymentObject(
-		kcfg.Clientset,
-		"app.kubernetes.io/instance",
-		"crossplane",
-		"crossplane-system",
-		3600,
-	)
-	if err != nil {
-		log.Error().Msgf("Error finding crossplane Deployment: %s", err)
+	if err := ctrl.FinalCheck(); err != nil {
+		log.Error().Msgf("error doing final check: %s", err)
 		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error finding crossplane Deployment: %w", err)
+		return fmt.Errorf("error doing final check: %w", err)
 	}
-	log.Info().Msg("waiting on dns, tls certificates from letsencrypt and remaining sync waves.\n this may take up to 60 minutes but regularly completes in under 20 minutes")
-	_, err = k8s.WaitForDeploymentReady(kcfg.Clientset, crossplaneDeployment, 3600)
-	if err != nil {
-		log.Error().Msgf("Error waiting for all Apps to sync ready state: %s", err)
-
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error waiting for all Apps to sync ready state: %w", err)
-	}
-
-	// * export and import cluster
-	err = ctrl.ExportClusterRecord()
-	if err != nil {
-		log.Error().Msgf("Error exporting cluster record: %s", err)
-		return fmt.Errorf("error exporting cluster record: %w", err)
-	}
-	ctrl.Cluster.Status = constants.ClusterStatusProvisioned
-	ctrl.Cluster.InProgress = false
-	err = secrets.UpdateCluster(ctrl.KubernetesClient, ctrl.Cluster)
-	if err != nil {
-		return fmt.Errorf("failed to update cluster after provisioning: %w", err)
-	}
-
-	log.Info().Msg("cluster creation complete")
-
-	// Create default service entries
-	cl, _ := secrets.GetCluster(ctrl.KubernetesClient, ctrl.ClusterName)
-	err = services.AddDefaultServices(cl)
-	if err != nil {
-		log.Error().Msgf("error adding default service entries for cluster %s: %s", cl.ClusterName, err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error adding default service entries for cluster %s: %w", cl.ClusterName, err)
-	}
-
-	if ctrl.InstallKubefirstPro {
-		log.Info().Msg("waiting for kubefirst-pro-api Deployment to transition to Running")
-		kubefirstProAPI, err := k8s.ReturnDeploymentObject(
-			kcfg.Clientset,
-			"app.kubernetes.io/name",
-			"kubefirst-pro-api",
-			"kubefirst",
-			1200,
-		)
-		if err != nil {
-			log.Error().Msgf("Error finding kubefirst-pro-api Deployment: %s", err)
-			ctrl.UpdateClusterOnError(err.Error())
-			return fmt.Errorf("error finding kubefirst-pro-api Deployment: %w", err)
-		}
-
-		_, err = k8s.WaitForDeploymentReady(kcfg.Clientset, kubefirstProAPI, 300)
-		if err != nil {
-			log.Error().Msgf("Error waiting for kubefirst-pro-api to transition to Running: %s", err)
-
-			ctrl.UpdateClusterOnError(err.Error())
-			return fmt.Errorf("error waiting for kubefirst-pro-api to transition to Running: %w", err)
-		}
-	}
-
-	// Wait for last sync wave app transition to Running
-	log.Info().Msg("waiting for final sync wave Deployment to transition to Running")
-	argocdDeployment, err := k8s.ReturnDeploymentObject(
-		kcfg.Clientset,
-		"app.kubernetes.io/name",
-		"argocd-server",
-		"argocd",
-		3600,
-	)
-	if err != nil {
-		log.Error().Msgf("Error finding argocd Deployment: %s", err)
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error finding argocd Deployment: %w", err)
-	}
-	_, err = k8s.WaitForDeploymentReady(kcfg.Clientset, argocdDeployment, 3600)
-	if err != nil {
-		log.Error().Msgf("Error waiting for argocd deployment to enter Ready state: %s", err)
-
-		ctrl.UpdateClusterOnError(err.Error())
-		return fmt.Errorf("error waiting for argocd deployment to enter Ready state: %w", err)
-	}
-
-	log.Info().Msg("cluster creation complete")
 
 	return nil
 }


### PR DESCRIPTION
## Description
As there were changes in removal of bubbletea in cli,we need another step in api to confirm the actual process completion otherwise the cli will display cluster creation complete even before crossplane,Kubefirst getting synced


## Testing 

in Kubefirst go.mod add replace github.com/konstructio/kubefirst-api v0.122.0 => <PATH_TO _KUBEFIRST_API_WITH_fix-steps-branch> and run `go run . civo create ...`