### PR TITLE
chore: update k3d to v5.8.3 and k3s to v1.28.12

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -177,7 +177,7 @@ func ReadConfig() (*Config, error) {
 	config.ArgoCDInitValuesYamlPath = fmt.Sprintf("%s/argocd-init-values.yaml", config.K1FolderPath)
 	// todo adopt latest helmVersion := "v3.9.0"
 	config.HelmVersion = "v3.6.1"
-	config.K3dVersion = "v5.4.6"
+	config.K3dVersion = "v5.8.3"
 
 	//! cleanup below this line?
 	config.InstallerEmail = "kbot@kubefirst.com"

--- a/internal/k3d/config.go
+++ b/internal/k3d/config.go
@@ -21,7 +21,7 @@ const (
 	DomainName           = "kubefirst.dev"
 	GithubHost           = "github.com"
 	GitlabHost           = "gitlab.com"
-	K3dVersion           = "v5.4.6"
+	K3dVersion           = "v5.8.3"
 	KubectlVersion       = "v1.25.7"
 	LocalhostARCH        = runtime.GOARCH
 	LocalhostOS          = runtime.GOOS

--- a/internal/k3d/create.go
+++ b/internal/k3d/create.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	// https://hub.docker.com/r/rancher/k3s/tags?page=1&name=v1.23
-	k3dImageTag string = "v1.26.3-k3s1"
+	// https://hub.docker.com/r/rancher/k3s/tags
+	k3dImageTag string = "v1.28.12-k3s1"
 )
 
 // ClusterCreate create an k3d cluster


### PR DESCRIPTION
## Summary
- Bump k3d version from v5.4.6 to v5.8.3
- Bump k3s image tag from v1.26.3-k3s1 to v1.28.12-k3s1

## Test plan
- [ ] Verify k3d cluster creation works with the new versions
- [ ] Test local development workflow with updated k3d/k3s